### PR TITLE
[weather-voodoo] Saved/recent locations with one-tap recall

### DIFF
--- a/weather-voodoo/src/lib/client/recentPlaces.svelte.ts
+++ b/weather-voodoo/src/lib/client/recentPlaces.svelte.ts
@@ -1,0 +1,117 @@
+import type { LabeledPoint } from '$lib/types';
+
+export type SavedPlace = LabeledPoint & {
+	label: string;
+	pinned: boolean;
+	lastUsed: number;
+};
+
+const STORAGE_KEY = 'wv.places.v1';
+const MAX_RECENT = 8;
+const COORD_PRECISION = 4;
+
+function roundCoord(n: number): number {
+	const p = 10 ** COORD_PRECISION;
+	return Math.round(n * p) / p;
+}
+
+function sameSpot(a: SavedPlace, b: { lat: number; lon: number }): boolean {
+	return roundCoord(a.lat) === roundCoord(b.lat) && roundCoord(a.lon) === roundCoord(b.lon);
+}
+
+function read(): SavedPlace[] {
+	if (typeof localStorage === 'undefined') return [];
+	try {
+		const raw = localStorage.getItem(STORAGE_KEY);
+		if (!raw) return [];
+		const parsed = JSON.parse(raw) as unknown;
+		if (!Array.isArray(parsed)) return [];
+		return parsed
+			.filter((p): p is SavedPlace => {
+				if (!p || typeof p !== 'object') return false;
+				const o = p as Record<string, unknown>;
+				return (
+					typeof o.lat === 'number' &&
+					typeof o.lon === 'number' &&
+					typeof o.label === 'string' &&
+					typeof o.pinned === 'boolean' &&
+					typeof o.lastUsed === 'number'
+				);
+			})
+			.slice(0, 64);
+	} catch {
+		return [];
+	}
+}
+
+function write(places: SavedPlace[]): void {
+	if (typeof localStorage === 'undefined') return;
+	try {
+		localStorage.setItem(STORAGE_KEY, JSON.stringify(places));
+	} catch {
+		// quota / private mode — ignore
+	}
+}
+
+export function sortForDisplay(places: SavedPlace[]): SavedPlace[] {
+	return [...places].sort((a, b) => {
+		if (a.pinned !== b.pinned) return a.pinned ? -1 : 1;
+		return b.lastUsed - a.lastUsed;
+	});
+}
+
+export function trimRecents(places: SavedPlace[], maxRecent = MAX_RECENT): SavedPlace[] {
+	const pinned = places.filter((p) => p.pinned);
+	const recents = places
+		.filter((p) => !p.pinned)
+		.sort((a, b) => b.lastUsed - a.lastUsed)
+		.slice(0, maxRecent);
+	return [...pinned, ...recents];
+}
+
+export const places = $state<{ items: SavedPlace[] }>({ items: [] });
+
+export function loadPlaces(): void {
+	places.items = read();
+}
+
+export function addRecent(p: LabeledPoint): void {
+	const label = p.label?.trim() || `${p.lat.toFixed(3)}, ${p.lon.toFixed(3)}`;
+	const existing = places.items.find((x) => sameSpot(x, p));
+	const now = Date.now();
+	let next: SavedPlace[];
+	if (existing) {
+		next = places.items.map((x) =>
+			sameSpot(x, p) ? { ...x, label, lastUsed: now } : x
+		);
+	} else {
+		const fresh: SavedPlace = {
+			lat: p.lat,
+			lon: p.lon,
+			label,
+			pinned: false,
+			lastUsed: now
+		};
+		next = [fresh, ...places.items];
+	}
+	places.items = trimRecents(next);
+	write(places.items);
+}
+
+export function togglePin(target: { lat: number; lon: number }): void {
+	const next = places.items.map((x) =>
+		sameSpot(x, target) ? { ...x, pinned: !x.pinned } : x
+	);
+	places.items = trimRecents(next);
+	write(places.items);
+}
+
+export function removePlace(target: { lat: number; lon: number }): void {
+	places.items = places.items.filter((x) => !sameSpot(x, target));
+	write(places.items);
+}
+
+export function clearAll(): void {
+	places.items = [];
+	write(places.items);
+}

--- a/weather-voodoo/src/lib/components/FixedView.svelte
+++ b/weather-voodoo/src/lib/components/FixedView.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
 	import { view, toggleExpanded, effectiveConfig, setDayOverride, resetDayOverride } from '$lib/state.svelte';
 	import PlaceSearch from './PlaceSearch.svelte';
+	import PlacesChips from './PlacesChips.svelte';
 	import MapView from './MapView.svelte';
 	import DayTabs from './DayTabs.svelte';
 	import ForecastTable from './ForecastTable.svelte';
 	import TripFinder from './TripFinder.svelte';
 	import { getCurrentPosition } from '$lib/client/geolocation';
+	import { addRecent } from '$lib/client/recentPlaces.svelte';
 	import { mergeSinglePoint } from '$lib/fusion';
 	import { resolveMode } from '$lib/trip-score';
 	import { filterHoursForDay, localIsoDate } from '$lib/time';
@@ -85,6 +87,7 @@
 
 	function pick(p: LabeledPoint) {
 		view.at = p;
+		if (p.label) addRecent(p);
 	}
 	function onMapPick(p: { lat: number; lon: number }) {
 		view.at = { ...p };
@@ -110,6 +113,7 @@
 				// keep coord fallback label
 			}
 			view.at = { lat, lon, label };
+			addRecent({ lat, lon, label });
 		} catch (e) {
 			error = e instanceof Error ? e.message : 'Geolocation failed';
 		} finally {
@@ -127,6 +131,7 @@
 			{geolocating ? 'Locating…' : '📍 Use my location'}
 		</button>
 	</div>
+	<PlacesChips onPick={pick} />
 	<div class="muted" style="margin-top: 0.5rem;">
 		{#if view.at}
 			<span>{view.at.label ?? `${view.at.lat.toFixed(3)}, ${view.at.lon.toFixed(3)}`}</span>

--- a/weather-voodoo/src/lib/components/PlaceSearch.svelte
+++ b/weather-voodoo/src/lib/components/PlaceSearch.svelte
@@ -8,9 +8,10 @@
 		placeholder?: string;
 		initial?: string;
 		onSelect: (p: LabeledPoint) => void;
+		onFocus?: () => void;
 	};
 
-	let { placeholder = 'Search a place…', initial = '', onSelect }: Props = $props();
+	let { placeholder = 'Search a place…', initial = '', onSelect, onFocus }: Props = $props();
 
 	let q = $state(initial ?? '');
 	let lastInitial = $state(initial ?? '');
@@ -95,6 +96,7 @@
 		bind:this={input}
 		bind:value={q}
 		oninput={onInput}
+		onfocus={() => onFocus?.()}
 		{placeholder}
 		class="input"
 		type="search"

--- a/weather-voodoo/src/lib/components/PlacesChips.svelte
+++ b/weather-voodoo/src/lib/components/PlacesChips.svelte
@@ -75,9 +75,11 @@
 		border: none;
 		font: inherit;
 		cursor: pointer;
-		padding: 0.25rem 0.6rem;
+		padding: 0.4rem 0.7rem;
+		min-height: 36px;
 	}
-	.chip button:hover {
+	.chip button:hover,
+	.chip button:focus-visible {
 		background: var(--bg-elev, rgba(255, 255, 255, 0.06));
 	}
 	.chip-main {
@@ -86,24 +88,42 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 	}
-	.chip-pin {
-		padding-left: 0.35rem !important;
-		padding-right: 0.35rem !important;
+	.chip-pin,
+	.chip-del {
+		min-width: 36px;
+		padding-left: 0.5rem !important;
+		padding-right: 0.5rem !important;
 		border-left: 1px solid var(--border);
 		color: var(--fg-dim);
+		font-size: 1.05em;
+		line-height: 1;
 	}
 	.chip.pinned .chip-pin {
 		color: var(--good, #4ade80);
 	}
-	.chip-del {
-		padding-left: 0.35rem !important;
-		padding-right: 0.5rem !important;
-		color: var(--fg-dim);
-		border-left: 1px solid var(--border);
-		font-size: 0.95em;
-		line-height: 1;
-	}
 	.chip-del:hover {
 		color: var(--unsafe, #ef4444);
+	}
+	@media (max-width: 720px) {
+		.places-chips {
+			gap: 0.45rem;
+		}
+		.chip {
+			font-size: 0.95em;
+		}
+		.chip button {
+			padding: 0.55rem 0.8rem;
+			min-height: 44px;
+		}
+		.chip-pin,
+		.chip-del {
+			min-width: 44px;
+			padding-left: 0.65rem !important;
+			padding-right: 0.65rem !important;
+			font-size: 1.15em;
+		}
+		.chip-main {
+			max-width: 10rem;
+		}
 	}
 </style>

--- a/weather-voodoo/src/lib/components/PlacesChips.svelte
+++ b/weather-voodoo/src/lib/components/PlacesChips.svelte
@@ -1,0 +1,109 @@
+<script lang="ts">
+	import { places, sortForDisplay, togglePin, removePlace, type SavedPlace } from '$lib/client/recentPlaces.svelte';
+	import type { LabeledPoint } from '$lib/types';
+
+	type Props = {
+		onPick: (p: LabeledPoint) => void;
+	};
+	let { onPick }: Props = $props();
+
+	const ordered = $derived(sortForDisplay(places.items));
+
+	function shortLabel(label: string): string {
+		const head = label.split(',')[0]?.trim();
+		return head && head.length > 0 ? head : label;
+	}
+
+	function pick(p: SavedPlace) {
+		onPick({ lat: p.lat, lon: p.lon, label: p.label });
+	}
+</script>
+
+{#if ordered.length > 0}
+	<div class="places-chips" role="list">
+		{#each ordered as p (`${p.lat}-${p.lon}`)}
+			<div class="chip" class:pinned={p.pinned} role="listitem">
+				<button
+					type="button"
+					class="chip-main"
+					title={p.label}
+					onclick={() => pick(p)}
+				>{shortLabel(p.label)}</button>
+				<button
+					type="button"
+					class="chip-pin"
+					title={p.pinned ? 'Unpin' : 'Pin so it stays in the list'}
+					aria-label={p.pinned ? 'Unpin' : 'Pin'}
+					onclick={() => togglePin(p)}
+				>{p.pinned ? '★' : '☆'}</button>
+				{#if !p.pinned}
+					<button
+						type="button"
+						class="chip-del"
+						title="Remove from recents"
+						aria-label="Remove"
+						onclick={() => removePlace(p)}
+					>×</button>
+				{/if}
+			</div>
+		{/each}
+	</div>
+{/if}
+
+<style>
+	.places-chips {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		margin-top: 0.5rem;
+	}
+	.chip {
+		display: inline-flex;
+		align-items: stretch;
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		background: var(--bg);
+		overflow: hidden;
+		font-size: 0.85em;
+	}
+	.chip.pinned {
+		border-color: var(--good, #4ade80);
+	}
+	.chip button {
+		background: transparent;
+		color: var(--fg);
+		border: none;
+		font: inherit;
+		cursor: pointer;
+		padding: 0.25rem 0.6rem;
+	}
+	.chip button:hover {
+		background: var(--bg-elev, rgba(255, 255, 255, 0.06));
+	}
+	.chip-main {
+		max-width: 14rem;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+	.chip-pin {
+		padding-left: 0.35rem !important;
+		padding-right: 0.35rem !important;
+		border-left: 1px solid var(--border);
+		color: var(--fg-dim);
+	}
+	.chip.pinned .chip-pin {
+		color: var(--good, #4ade80);
+	}
+	.chip-del {
+		padding-left: 0.35rem !important;
+		padding-right: 0.5rem !important;
+		color: var(--fg-dim);
+		border-left: 1px solid var(--border);
+		font-size: 0.95em;
+		line-height: 1;
+	}
+	.chip-del:hover {
+		color: var(--unsafe, #ef4444);
+	}
+</style>

--- a/weather-voodoo/src/lib/components/RouteView.svelte
+++ b/weather-voodoo/src/lib/components/RouteView.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
 	import { view, toggleExpanded, effectiveConfig, setDayOverride, resetDayOverride } from '$lib/state.svelte';
 	import PlaceSearch from './PlaceSearch.svelte';
+	import PlacesChips from './PlacesChips.svelte';
 	import MapView from './MapView.svelte';
 	import DayTabs from './DayTabs.svelte';
 	import ForecastTable from './ForecastTable.svelte';
 	import TripFinder from './TripFinder.svelte';
 	import { resolveMode } from '$lib/trip-score';
 	import { filterHoursForDay, localIsoDate } from '$lib/time';
+	import { addRecent } from '$lib/client/recentPlaces.svelte';
 	import type { FusedHour, LabeledPoint, DayKey } from '$lib/types';
 
 	let loading = $state(false);
@@ -64,9 +66,20 @@
 
 	function pickFrom(p: LabeledPoint) {
 		view.from = p;
+		if (p.label) addRecent(p);
 	}
 	function pickTo(p: LabeledPoint) {
 		view.to = p;
+		if (p.label) addRecent(p);
+	}
+	function pickFromChip(p: LabeledPoint) {
+		if (!view.from) {
+			pickFrom(p);
+		} else if (!view.to) {
+			pickTo(p);
+		} else {
+			pickTo(p);
+		}
 	}
 	function onMapPick(p: { lat: number; lon: number }) {
 		if (!view.from) view.from = { ...p };
@@ -83,6 +96,7 @@
 		<PlaceSearch placeholder="From — search or click on map" initial={view.from?.label} onSelect={pickFrom} />
 		<PlaceSearch placeholder="To — search or click on map" initial={view.to?.label} onSelect={pickTo} />
 	</div>
+	<PlacesChips onPick={pickFromChip} />
 	<div class="muted" style="margin-top: 0.5rem;">
 		{#if view.from}<span>From: {view.from.label ?? `${view.from.lat.toFixed(3)}, ${view.from.lon.toFixed(3)}`}</span>{/if}
 		{#if view.from && view.to}<span> · </span>{/if}

--- a/weather-voodoo/src/lib/components/RouteView.svelte
+++ b/weather-voodoo/src/lib/components/RouteView.svelte
@@ -64,6 +64,8 @@
 	);
 	const activeMode = $derived(result ? resolveMode(eff.mode, dayHours) : 'sea');
 
+	let lastFocused: 'from' | 'to' | null = $state(null);
+
 	function pickFrom(p: LabeledPoint) {
 		view.from = p;
 		if (p.label) addRecent(p);
@@ -73,7 +75,11 @@
 		if (p.label) addRecent(p);
 	}
 	function pickFromChip(p: LabeledPoint) {
-		if (!view.from) {
+		if (lastFocused === 'from') {
+			pickFrom(p);
+		} else if (lastFocused === 'to') {
+			pickTo(p);
+		} else if (!view.from) {
 			pickFrom(p);
 		} else if (!view.to) {
 			pickTo(p);
@@ -93,8 +99,18 @@
 
 <div class="card">
 	<div class="row">
-		<PlaceSearch placeholder="From — search or click on map" initial={view.from?.label} onSelect={pickFrom} />
-		<PlaceSearch placeholder="To — search or click on map" initial={view.to?.label} onSelect={pickTo} />
+		<PlaceSearch
+			placeholder="From — search or click on map"
+			initial={view.from?.label}
+			onSelect={pickFrom}
+			onFocus={() => (lastFocused = 'from')}
+		/>
+		<PlaceSearch
+			placeholder="To — search or click on map"
+			initial={view.to?.label}
+			onSelect={pickTo}
+			onFocus={() => (lastFocused = 'to')}
+		/>
 	</div>
 	<PlacesChips onPick={pickFromChip} />
 	<div class="muted" style="margin-top: 0.5rem;">

--- a/weather-voodoo/src/routes/+layout.svelte
+++ b/weather-voodoo/src/routes/+layout.svelte
@@ -4,6 +4,7 @@
 	import { onMount } from 'svelte';
 	import { decodeView, defaultState, encodeView, viewsEqual } from '$lib/url-state';
 	import { setView, view } from '$lib/state.svelte';
+	import { loadPlaces } from '$lib/client/recentPlaces.svelte';
 	import ShareBar from '$lib/components/ShareBar.svelte';
 
 	let { children } = $props();
@@ -28,6 +29,7 @@
 	}
 
 	onMount(() => {
+		loadPlaces();
 		const decoded = decodeView(paramsFromLocation());
 		setView(decoded);
 		lastSerialized = encodeView(decoded);

--- a/weather-voodoo/tests/recent-places.test.ts
+++ b/weather-voodoo/tests/recent-places.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { sortForDisplay, trimRecents, type SavedPlace } from '../src/lib/client/recentPlaces.svelte';
+
+function mk(overrides: Partial<SavedPlace>): SavedPlace {
+	return {
+		lat: 0,
+		lon: 0,
+		label: 'X',
+		pinned: false,
+		lastUsed: 0,
+		...overrides
+	};
+}
+
+describe('sortForDisplay', () => {
+	it('puts pinned before recent regardless of lastUsed', () => {
+		const items = [
+			mk({ label: 'recent-newer', lastUsed: 200 }),
+			mk({ label: 'pinned-older', pinned: true, lastUsed: 50 }),
+			mk({ label: 'recent-older', lastUsed: 100 })
+		];
+		const order = sortForDisplay(items).map((p) => p.label);
+		expect(order).toEqual(['pinned-older', 'recent-newer', 'recent-older']);
+	});
+
+	it('orders by lastUsed within each group, newest first', () => {
+		const items = [
+			mk({ label: 'pin-A', pinned: true, lastUsed: 100 }),
+			mk({ label: 'pin-B', pinned: true, lastUsed: 300 }),
+			mk({ label: 'r-A', lastUsed: 1000 }),
+			mk({ label: 'r-B', lastUsed: 999 })
+		];
+		const order = sortForDisplay(items).map((p) => p.label);
+		expect(order).toEqual(['pin-B', 'pin-A', 'r-A', 'r-B']);
+	});
+});
+
+describe('trimRecents', () => {
+	it('keeps all pinned even when there are many', () => {
+		const items: SavedPlace[] = Array.from({ length: 20 }, (_, i) =>
+			mk({ label: `pin-${i}`, pinned: true, lat: i, lastUsed: i })
+		);
+		const out = trimRecents(items, 5);
+		expect(out).toHaveLength(20);
+		expect(out.every((p) => p.pinned)).toBe(true);
+	});
+
+	it('evicts the oldest recents past the cap', () => {
+		const items: SavedPlace[] = [
+			mk({ label: 'old', lastUsed: 1, lat: 1 }),
+			mk({ label: 'mid', lastUsed: 5, lat: 2 }),
+			mk({ label: 'new', lastUsed: 10, lat: 3 })
+		];
+		const out = trimRecents(items, 2);
+		const labels = out.map((p) => p.label).sort();
+		expect(labels).toEqual(['mid', 'new']);
+	});
+
+	it('combines pinned + capped recents', () => {
+		const items: SavedPlace[] = [
+			mk({ label: 'pin', pinned: true, lat: 0, lastUsed: 1 }),
+			mk({ label: 'old', lat: 1, lastUsed: 1 }),
+			mk({ label: 'mid', lat: 2, lastUsed: 5 }),
+			mk({ label: 'new', lat: 3, lastUsed: 10 })
+		];
+		const out = trimRecents(items, 2);
+		expect(out).toHaveLength(3);
+		const labels = out.map((p) => p.label).sort();
+		expect(labels).toEqual(['mid', 'new', 'pin']);
+	});
+});


### PR DESCRIPTION
Closes #15.

## Summary
A horizontal chip row under each search input listing recent + pinned places. Tapping a chip fills the search and triggers the forecast — no re-typing "Phi Phi" every visit.

## Changes
- **`src/lib/client/recentPlaces.svelte.ts`** — new `$state`-backed store of `{lat, lon, label, pinned, lastUsed}`, persisted to `localStorage` under `wv.places.v1`. Up to 8 recents kept; pinned places stay unlimited.
- **`src/lib/components/PlacesChips.svelte`** — chip-row component, per-chip `☆/★` pin toggle and `×` remove (hidden for pinned chips).
- **`FixedView`** / **`RouteView`** — both call `addRecent` after a search pick or `Use my location`. Chip taps fill the relevant field:
  - Fixed: sets `at`.
  - Route: fills the last-focused field (From or To); falls back to first-empty, then replaces To.
- **`PlaceSearch`** — exposes an `onFocus` callback so RouteView can track which input was last focused.
- **`+layout.svelte`** — calls `loadPlaces()` on mount. The existing Reset / logo-home clears only in-flight state; the saved list survives by design.
- Chip buttons have larger hit targets on mobile (≥44 px per Apple/Material guidance).
- Tests for the pure helpers (`sortForDisplay`, `trimRecents`).

## Open questions (deferred)
- "Recent" is shared between tabs — easiest mental model. Open to per-tab scoping if it turns out to be confusing in practice.
- Did not persist `tripDurationH` / `tripMode` per place as a preset; can be a follow-up.

## Test plan
- [x] `pnpm test` (67 passing, +5 new)
- [x] `pnpm check` (no new errors)
- [x] Manual: seeded localStorage with 2 places, chips render with short labels; tapping a chip fills whichever field was last focused; Reset preserves the list; ★/☆ toggle persists across reload; × removes only unpinned chips.