### PR TITLE
[weather-voodoo] Sunrise / sunset markers in the forecast table

### DIFF
--- a/weather-voodoo/src/lib/components/FixedView.svelte
+++ b/weather-voodoo/src/lib/components/FixedView.svelte
@@ -11,11 +11,13 @@
 	import { mergeSinglePoint } from '$lib/fusion';
 	import { resolveMode } from '$lib/trip-score';
 	import { filterHoursForDay, localIsoDate } from '$lib/time';
-	import type { FusedHour, ForecastHour, LabeledPoint, MarineHour, DayKey } from '$lib/types';
+	import type { DaylightDay, FusedHour, ForecastHour, LabeledPoint, MarineHour, DayKey } from '$lib/types';
 
 	let loading = $state(false);
 	let error = $state<string | null>(null);
-	let result = $state<{ hours: FusedHour[]; timezone: string } | null>(null);
+	let result = $state<{ hours: FusedHour[]; timezone: string; daylight: DaylightDay[] } | null>(
+		null
+	);
 	let owmAlerts = $state<{ event: string; description: string }[]>([]);
 	let aqi = $state<number | null>(null);
 
@@ -34,7 +36,14 @@
 		Promise.all([
 			fetch(`/api/forecast?lat=${at.lat.toFixed(4)}&lon=${at.lon.toFixed(4)}&days=3`, {
 				signal: ac.signal
-			}).then((r) => r.json() as Promise<{ timezone: string; hours: ForecastHour[] }>),
+			}).then(
+				(r) =>
+					r.json() as Promise<{
+						timezone: string;
+						hours: ForecastHour[];
+						daylight?: DaylightDay[];
+					}>
+			),
 			fetch(`/api/marine?lat=${at.lat.toFixed(4)}&lon=${at.lon.toFixed(4)}&days=3`, {
 				signal: ac.signal
 			})
@@ -44,7 +53,8 @@
 			.then(([f, m]) => {
 				result = {
 					timezone: f.timezone,
-					hours: mergeSinglePoint(f.hours, m.hours.length ? m.hours : null)
+					hours: mergeSinglePoint(f.hours, m.hours.length ? m.hours : null),
+					daylight: f.daylight ?? []
 				};
 			})
 			.catch((e: unknown) => {
@@ -188,6 +198,7 @@
 				expanded={view.expanded}
 				onToggleSlot={toggleExpanded}
 				{todayIso}
+				daylight={result.daylight}
 			/>
 		{/if}
 	</div>

--- a/weather-voodoo/src/lib/components/ForecastRow.svelte
+++ b/weather-voodoo/src/lib/components/ForecastRow.svelte
@@ -7,7 +7,8 @@
 	import WxIcon from './icons/WxIcon.svelte';
 	import HourCell from './HourCell.svelte';
 	import MarineBlock from './MarineBlock.svelte';
-	import type { FusedHour } from '$lib/types';
+	import type { DaylightDay, FusedHour } from '$lib/types';
+	import { isDaylight, sunPhase } from '$lib/daylight';
 
 	type Props = {
 		slot: ThreeHourAggregate;
@@ -18,6 +19,7 @@
 		hourScores: Map<string, number | null>;
 		outsideInterval: Set<string>;
 		outsideStartRange: Set<string>;
+		dayInfo?: DaylightDay;
 	};
 
 	let {
@@ -28,8 +30,19 @@
 		mode,
 		hourScores,
 		outsideInterval,
-		outsideStartRange
+		outsideStartRange,
+		dayInfo
 	}: Props = $props();
+
+	const slotNight = $derived(
+		slot.hours.length > 0 && slot.hours.every((h) => !isDaylight(h.time, dayInfo))
+	);
+	const slotMixed = $derived(
+		!slotNight && slot.hours.some((h) => !isDaylight(h.time, dayInfo))
+	);
+	const slotPhases = $derived(slot.hours.map((h) => sunPhase(h.time, dayInfo)));
+	const slotHasSunrise = $derived(slotPhases.some((p) => p === 'sunrise-hour'));
+	const slotHasSunset = $derived(slotPhases.some((p) => p === 'sunset-hour'));
 
 	const highlightStartMs = $derived(view.highlight ? Date.parse(view.highlight + ':00Z') : null);
 	const highlightEndMs = $derived(
@@ -92,6 +105,8 @@
 	class="slot"
 	class:highlight={slotHighlighted}
 	class:disabled={!slotCovered}
+	class:night={slotNight}
+	class:dim={slotMixed}
 	data-slot-start={start}
 	style="--row-bg: {rowCss.bg}; --row-border: {rowCss.border};"
 	onclick={onToggle}
@@ -99,6 +114,7 @@
 	<td>
 		<span class="expand-caret" class:open={expanded}>▶</span>
 		{start}–{end}
+		{#if slotHasSunrise}<span class="sun-marker" title="Sunrise in this block">🌅</span>{:else if slotHasSunset}<span class="sun-marker" title="Sunset in this block">🌇</span>{:else if slotNight}<span class="sun-marker" title="Night">🌙</span>{/if}
 		<span class="row-score" title="Best start within this block (window score 0–100)">
 			{slotScore == null ? '—' : slotScore}
 		</span>
@@ -131,6 +147,7 @@
 			outside={outsideInterval.has(h.time)}
 			coveredOnly={!outsideInterval.has(h.time) && outsideStartRange.has(h.time)}
 			highlighted={isHourHighlighted(h.time)}
+			{dayInfo}
 		/>
 	{/each}
 {/if}
@@ -145,6 +162,17 @@
 	}
 	tr.slot.disabled {
 		opacity: 0.55;
+	}
+	tr.slot.night :global(td) {
+		background-image: linear-gradient(rgba(15, 23, 42, 0.4), rgba(15, 23, 42, 0.4));
+	}
+	tr.slot.dim :global(td) {
+		background-image: linear-gradient(rgba(15, 23, 42, 0.18), rgba(15, 23, 42, 0.18));
+	}
+	.sun-marker {
+		margin-left: 0.3rem;
+		font-size: 0.92em;
+		vertical-align: -1px;
 	}
 	.row-score {
 		display: inline-block;

--- a/weather-voodoo/src/lib/components/ForecastTable.svelte
+++ b/weather-voodoo/src/lib/components/ForecastTable.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import type { DayOverride, DayKey, FusedHour, TripMode } from '$lib/types';
+	import type { DayOverride, DayKey, DaylightDay, FusedHour, TripMode } from '$lib/types';
 	import { aggregate3h } from '$lib/fusion';
 	import { filterHoursForDay } from '$lib/time';
+	import { dayLookup } from '$lib/daylight';
 	import { hourTripScore, windowScoreAt } from '$lib/trip-score';
 	import { minToHHMM, hhmmToMin } from '$lib/url-state';
 	import ForecastRow from './ForecastRow.svelte';
@@ -23,6 +24,7 @@
 		expanded: Set<string>;
 		onToggleSlot: (slot: string) => void;
 		todayIso: string;
+		daylight?: DaylightDay[];
 	};
 
 	let {
@@ -41,8 +43,19 @@
 		onResetOverride,
 		expanded,
 		onToggleSlot,
-		todayIso
+		todayIso,
+		daylight = []
 	}: Props = $props();
+
+	const daylightMap = $derived(dayLookup(daylight));
+	const todayDaylight = $derived(() => {
+		const [y, m, d] = todayIso.split('-').map(Number);
+		const target = new Date(y, (m ?? 1) - 1, d ?? 1);
+		const off = day === 'today' ? 0 : day === 'tomorrow' ? 1 : 2;
+		target.setDate(target.getDate() + off);
+		const iso = `${target.getFullYear()}-${String(target.getMonth() + 1).padStart(2, '0')}-${String(target.getDate()).padStart(2, '0')}`;
+		return daylightMap.get(iso);
+	});
 
 	const dayHours = $derived(filterHoursForDay(allHours, day, todayIso));
 	const slots = $derived(aggregate3h(dayHours));
@@ -208,6 +221,17 @@
 
 <svelte:window onkeydown={onKey} />
 
+{#if todayDaylight()}
+	{@const dl = todayDaylight()}
+	{#if dl}
+		<div class="sun-times muted">
+			<span>☀️ Sunrise <strong>{dl.sunrise.slice(11, 16)}</strong></span>
+			<span>·</span>
+			<span>🌙 Sunset <strong>{dl.sunset.slice(11, 16)}</strong></span>
+		</div>
+	{/if}
+{/if}
+
 <div class="interval-bar">
 	<span class="muted" style="font-size: 0.85em; margin-right: 0.4rem;">For this day:</span>
 	<label>
@@ -328,6 +352,7 @@
 						{hourScores}
 						{outsideInterval}
 						{outsideStartRange}
+						dayInfo={todayDaylight()}
 					/>
 				{/each}
 			</tbody>
@@ -359,6 +384,17 @@
 {/if}
 
 <style>
+	.sun-times {
+		display: flex;
+		gap: 0.5rem;
+		align-items: center;
+		font-size: 0.85em;
+		padding: 0.35rem 0.1rem 0.45rem;
+	}
+	.sun-times strong {
+		color: var(--fg);
+		font-variant-numeric: tabular-nums;
+	}
 	.interval-bar {
 		display: flex;
 		gap: 0.6rem;

--- a/weather-voodoo/src/lib/components/HourCell.svelte
+++ b/weather-voodoo/src/lib/components/HourCell.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-	import type { FusedHour } from '$lib/types';
+	import type { DaylightDay, FusedHour } from '$lib/types';
 	import { degToCompass, round1 } from '$lib/units';
 	import { scoreToCss } from '$lib/trip-score';
+	import { isDaylight, sunPhase } from '$lib/daylight';
 	import WxIcon from './icons/WxIcon.svelte';
 
 	type Props = {
@@ -10,6 +11,7 @@
 		outside?: boolean;
 		coveredOnly?: boolean;
 		highlighted?: boolean;
+		dayInfo?: DaylightDay;
 	};
 
 	let {
@@ -17,9 +19,12 @@
 		score,
 		outside = false,
 		coveredOnly = false,
-		highlighted = false
+		highlighted = false,
+		dayInfo
 	}: Props = $props();
 	const timeLabel = $derived(hour.time.slice(11, 16));
+	const phase = $derived(sunPhase(hour.time, dayInfo));
+	const isNight = $derived(!isDaylight(hour.time, dayInfo));
 	const css = $derived(
 		score == null || outside
 			? { bg: 'transparent', border: 'transparent' }
@@ -38,11 +43,13 @@
 	class="detail hour"
 	class:highlight={highlighted}
 	class:outside
+	class:night={isNight}
 	data-hour-time={hour.time}
 	style="--row-bg: {css.bg}; --row-border: {css.border};"
 >
 	<td>
 		{timeLabel}
+		{#if phase === 'sunrise-hour'}<span class="sun-marker" title="Sunrise">🌅</span>{:else if phase === 'sunset-hour'}<span class="sun-marker" title="Sunset">🌇</span>{:else if isNight}<span class="sun-marker" title="Night">🌙</span>{/if}
 		<span class="hour-score" class:outside-chip={outside} title={chipTitle}>
 			{score == null ? '—' : score}
 		</span>
@@ -64,6 +71,15 @@
 	tr.hour {
 		background: var(--row-bg, transparent);
 		scroll-margin-top: 1rem;
+	}
+	tr.hour.night :global(td) {
+		background-image: linear-gradient(rgba(15, 23, 42, 0.4), rgba(15, 23, 42, 0.4));
+	}
+	.sun-marker {
+		margin-left: 0.25rem;
+		margin-right: 0.05rem;
+		font-size: 0.92em;
+		vertical-align: -1px;
 	}
 	tr.hour > td:first-child {
 		border-left: 4px solid var(--row-border, transparent);

--- a/weather-voodoo/src/lib/components/RouteView.svelte
+++ b/weather-voodoo/src/lib/components/RouteView.svelte
@@ -9,11 +9,13 @@
 	import { resolveMode } from '$lib/trip-score';
 	import { filterHoursForDay, localIsoDate } from '$lib/time';
 	import { addRecent } from '$lib/client/recentPlaces.svelte';
-	import type { FusedHour, LabeledPoint, DayKey } from '$lib/types';
+	import type { DaylightDay, FusedHour, LabeledPoint, DayKey } from '$lib/types';
 
 	let loading = $state(false);
 	let error = $state<string | null>(null);
-	let result = $state<{ hours: FusedHour[]; timezone: string } | null>(null);
+	let result = $state<{ hours: FusedHour[]; timezone: string; daylight: DaylightDay[] } | null>(
+		null
+	);
 
 	const markers = $derived(
 		[view.from, view.to].filter((m): m is LabeledPoint => m !== null)
@@ -44,8 +46,12 @@
 		)
 			.then(async (r) => {
 				if (!r.ok) throw new Error(`HTTP ${r.status}`);
-				const data = (await r.json()) as { hours: FusedHour[]; timezone: string };
-				result = data;
+				const data = (await r.json()) as {
+					hours: FusedHour[];
+					timezone: string;
+					daylight?: DaylightDay[];
+				};
+				result = { hours: data.hours, timezone: data.timezone, daylight: data.daylight ?? [] };
 			})
 			.catch((e: unknown) => {
 				if (e instanceof DOMException && e.name === 'AbortError') return;
@@ -154,6 +160,7 @@
 				expanded={view.expanded}
 				onToggleSlot={toggleExpanded}
 				{todayIso}
+				daylight={result.daylight}
 			/>
 		{/if}
 	</div>

--- a/weather-voodoo/src/lib/daylight.ts
+++ b/weather-voodoo/src/lib/daylight.ts
@@ -1,0 +1,30 @@
+import type { DaylightDay } from './types';
+
+export function dayLookup(daylight: DaylightDay[]): Map<string, DaylightDay> {
+	const m = new Map<string, DaylightDay>();
+	for (const d of daylight) m.set(d.date, d);
+	return m;
+}
+
+export function isDaylight(time: string, daylight: DaylightDay | undefined): boolean {
+	if (!daylight) return true;
+	const sr = daylight.sunrise;
+	const ss = daylight.sunset;
+	if (!sr || !ss) return true;
+	return time >= sr && time < ss;
+}
+
+export type SunPhase = 'pre-dawn' | 'sunrise-hour' | 'day' | 'sunset-hour' | 'night';
+
+export function sunPhase(time: string, daylight: DaylightDay | undefined): SunPhase {
+	if (!daylight) return 'day';
+	const sr = daylight.sunrise;
+	const ss = daylight.sunset;
+	if (!sr || !ss) return 'day';
+	const sameHour = (a: string, b: string) => a.slice(0, 13) === b.slice(0, 13);
+	if (sameHour(time, sr)) return 'sunrise-hour';
+	if (sameHour(time, ss)) return 'sunset-hour';
+	if (time < sr) return 'pre-dawn';
+	if (time >= ss) return 'night';
+	return 'day';
+}

--- a/weather-voodoo/src/lib/server/openmeteo.ts
+++ b/weather-voodoo/src/lib/server/openmeteo.ts
@@ -36,6 +36,7 @@ function buildForecastUrl(lat: number, lon: number, days: number): string {
 		latitude: lat.toString(),
 		longitude: lon.toString(),
 		hourly: FORECAST_VARS,
+		daily: 'sunrise,sunset',
 		forecast_days: days.toString(),
 		timezone: 'auto',
 		wind_speed_unit: 'kn'
@@ -75,6 +76,11 @@ type RawForecast = {
 		surface_pressure: number[];
 		uv_index?: (number | null)[];
 	};
+	daily?: {
+		time: string[];
+		sunrise: string[];
+		sunset: string[];
+	};
 };
 
 type RawMarine = {
@@ -90,7 +96,8 @@ type RawMarine = {
 	};
 };
 
-export type ForecastResult = { timezone: string; hours: ForecastHour[] };
+export type DaylightDay = { date: string; sunrise: string; sunset: string };
+export type ForecastResult = { timezone: string; hours: ForecastHour[]; daylight: DaylightDay[] };
 export type MarineResult = { timezone: string; hours: MarineHour[] } | null;
 
 export async function fetchForecast(lat: number, lon: number, days = 3): Promise<ForecastResult> {
@@ -103,7 +110,15 @@ export async function fetchForecast(lat: number, lon: number, days = 3): Promise
 		if (!res.ok) throw new Error(`Open-Meteo forecast HTTP ${res.status}`);
 		const data = (await res.json()) as RawForecast;
 		const h = data.hourly;
-		if (!h) return { timezone: data.timezone ?? 'UTC', hours: [] };
+		const d = data.daily;
+		const daylight: DaylightDay[] = d
+			? d.time.map((date, i) => ({
+					date,
+					sunrise: d.sunrise[i] ?? '',
+					sunset: d.sunset[i] ?? ''
+				}))
+			: [];
+		if (!h) return { timezone: data.timezone ?? 'UTC', hours: [], daylight };
 
 		const hours: ForecastHour[] = h.time.map((t, i) => ({
 			time: t,
@@ -123,7 +138,7 @@ export async function fetchForecast(lat: number, lon: number, days = 3): Promise
 			pressureHpa: h.surface_pressure[i] ?? 0,
 			uv: h.uv_index?.[i] ?? undefined
 		}));
-		return { timezone: data.timezone ?? 'UTC', hours };
+		return { timezone: data.timezone ?? 'UTC', hours, daylight };
 	});
 }
 

--- a/weather-voodoo/src/lib/types.ts
+++ b/weather-voodoo/src/lib/types.ts
@@ -63,6 +63,8 @@ export type FusedHour = ForecastHour & {
 	swellHsM: number | null;
 };
 
+export type DaylightDay = { date: string; sunrise: string; sunset: string };
+
 export type Activity =
 	| 'swimming'
 	| 'sunbathing'

--- a/weather-voodoo/src/routes/api/route/+server.ts
+++ b/weather-voodoo/src/routes/api/route/+server.ts
@@ -27,7 +27,7 @@ export const GET: RequestHandler = async ({ url }) => {
 		const results = await Promise.all(
 			points.map(async (p) => {
 				const [f, m] = await Promise.all([fetchForecast(p.lat, p.lon, days), fetchMarine(p.lat, p.lon, days)]);
-				return { forecast: f.hours, marine: m?.hours ?? null, timezone: f.timezone };
+				return { forecast: f.hours, marine: m?.hours ?? null, timezone: f.timezone, daylight: f.daylight };
 			})
 		);
 		const hours = fuseRoute(results);
@@ -35,7 +35,8 @@ export const GET: RequestHandler = async ({ url }) => {
 			{
 				timezone: results[0]?.timezone ?? 'UTC',
 				samplePoints: points,
-				hours
+				hours,
+				daylight: results[0]?.daylight ?? []
 			},
 			{ headers: { 'cache-control': 'public, s-maxage=600, stale-while-revalidate=3600' } }
 		);

--- a/weather-voodoo/tests/daylight.test.ts
+++ b/weather-voodoo/tests/daylight.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { dayLookup, isDaylight, sunPhase } from '../src/lib/daylight';
+import type { DaylightDay } from '../src/lib/types';
+
+const dl: DaylightDay = {
+	date: '2026-05-21',
+	sunrise: '2026-05-21T06:00',
+	sunset: '2026-05-21T18:30'
+};
+
+describe('isDaylight', () => {
+	it('treats sunrise → sunset as day', () => {
+		expect(isDaylight('2026-05-21T06:00', dl)).toBe(true);
+		expect(isDaylight('2026-05-21T12:00', dl)).toBe(true);
+		expect(isDaylight('2026-05-21T18:00', dl)).toBe(true);
+	});
+	it('treats before sunrise / at-or-after sunset as night', () => {
+		expect(isDaylight('2026-05-21T05:00', dl)).toBe(false);
+		expect(isDaylight('2026-05-21T18:30', dl)).toBe(false);
+		expect(isDaylight('2026-05-21T22:00', dl)).toBe(false);
+	});
+	it('defaults to true if no daylight info', () => {
+		expect(isDaylight('2026-05-21T03:00', undefined)).toBe(true);
+	});
+});
+
+describe('sunPhase', () => {
+	it('labels the sunrise hour and sunset hour', () => {
+		expect(sunPhase('2026-05-21T06:00', dl)).toBe('sunrise-hour');
+		expect(sunPhase('2026-05-21T18:00', dl)).toBe('sunset-hour');
+	});
+	it('labels other hours appropriately', () => {
+		expect(sunPhase('2026-05-21T03:00', dl)).toBe('pre-dawn');
+		expect(sunPhase('2026-05-21T12:00', dl)).toBe('day');
+		expect(sunPhase('2026-05-21T22:00', dl)).toBe('night');
+	});
+});
+
+describe('dayLookup', () => {
+	it('keys by date', () => {
+		const m = dayLookup([dl]);
+		expect(m.get('2026-05-21')).toBe(dl);
+		expect(m.get('2026-05-22')).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Closes #16.

## Summary
Make day vs night obvious in the forecast table without adding a noisy column.

## Changes
- **`src/lib/server/openmeteo.ts`** — adds `daily=sunrise,sunset` to the Open-Meteo forecast call; `fetchForecast` now returns `{ timezone, hours, daylight }`.
- **`src/routes/api/route/+server.ts`** — surfaces `daylight` from the first sample point in the route response (forecast endpoint already returns the full `ForecastResult`).
- **`src/lib/daylight.ts`** — new helper module: `dayLookup`, `isDaylight(time, day)`, `sunPhase(time, day)` → `'pre-dawn' | 'sunrise-hour' | 'day' | 'sunset-hour' | 'night'`.
- **`ForecastTable`** — looks up the active day's record and threads it to each row.
  - New "☀️ Sunrise HH:MM · 🌙 Sunset HH:MM" line above the per-day interval bar.
- **`ForecastRow` / `HourCell`**
  - Night rows get a subtle dark overlay so day vs night is obvious at a glance.
  - The TIME label shows 🌅 on the sunrise hour, 🌇 on the sunset hour, 🌙 at night. The aggregated 3-hour row gets the same marker when its hours span the transition.
- New `tests/daylight.test.ts` (6 tests).

## Test plan
- [x] `pnpm test` → 73 passing (+6 new).
- [x] `pnpm check` clean (only pre-existing warnings unchanged).
- [ ] Manual verify on preview build URL (will post in PR).

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9DMrLPT7hYfdCTsJgFF9q)_