### PR TITLE
[weather-voodoo] Help page + first-visit intro modal

### DIFF
--- a/weather-voodoo/src/lib/components/IntroModal.svelte
+++ b/weather-voodoo/src/lib/components/IntroModal.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+	type Props = {
+		onClose: () => void;
+	};
+	let { onClose }: Props = $props();
+
+	function onKey(e: KeyboardEvent) {
+		if (e.key === 'Escape') onClose();
+	}
+</script>
+
+<svelte:window onkeydown={onKey} />
+
+<div
+	class="intro-backdrop"
+	role="presentation"
+	onclick={onClose}
+	onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') onClose(); }}
+>
+	<div
+		class="intro-card"
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby="intro-title"
+		tabindex="-1"
+		onclick={(e) => e.stopPropagation()}
+		onkeydown={(e) => e.stopPropagation()}
+	>
+		<h2 id="intro-title">🌦️ Welcome to Weather Voodoo</h2>
+		<p>
+			Find the best hours of the next 3 days for an outdoor or marine trip. Wind, gust, rain,
+			wave and visibility are blended into a 0–100 score and the best contiguous windows are
+			surfaced for you.
+		</p>
+		<ul>
+			<li><strong>Route</strong>: forecast fused along a path (ferry / kayak / drive).</li>
+			<li><strong>Fixed location</strong>: one spot (beach, hike, sunset).</li>
+			<li>Pick a duration, a time window, and Sea / Land mode — the table colours each hour by score.</li>
+		</ul>
+		<div class="intro-actions">
+			<a class="btn-ghost" href="/help" onclick={onClose}>Read the full help</a>
+			<button type="button" class="btn" onclick={onClose}>Got it</button>
+		</div>
+	</div>
+</div>
+
+<style>
+	.intro-backdrop {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.6);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem;
+		z-index: 2000;
+	}
+	.intro-card {
+		background: var(--bg-elev, var(--bg));
+		color: var(--fg);
+		border: 1px solid var(--border);
+		border-radius: 12px;
+		padding: 1.2rem 1.4rem;
+		max-width: 28rem;
+		width: 100%;
+		box-shadow: 0 14px 40px rgba(0, 0, 0, 0.45);
+	}
+	.intro-card h2 {
+		margin: 0 0 0.6rem 0;
+		font-size: 1.15rem;
+	}
+	.intro-card p {
+		margin: 0 0 0.7rem 0;
+		line-height: 1.45;
+	}
+	.intro-card ul {
+		padding-left: 1.1rem;
+		margin: 0 0 1rem 0;
+		line-height: 1.5;
+	}
+	.intro-card li {
+		margin-bottom: 0.25rem;
+	}
+	.intro-actions {
+		display: flex;
+		gap: 0.5rem;
+		justify-content: flex-end;
+		flex-wrap: wrap;
+	}
+</style>

--- a/weather-voodoo/src/routes/+layout.svelte
+++ b/weather-voodoo/src/routes/+layout.svelte
@@ -6,10 +6,14 @@
 	import { setView, view } from '$lib/state.svelte';
 	import { loadPlaces } from '$lib/client/recentPlaces.svelte';
 	import ShareBar from '$lib/components/ShareBar.svelte';
+	import IntroModal from '$lib/components/IntroModal.svelte';
 
 	let { children } = $props();
 	let initialized = $state(false);
 	let lastSerialized = $state<string>('');
+	let showIntro = $state(false);
+
+	const INTRO_KEY = 'wv.introSeen.v1';
 
 	function paramsFromLocation(): URLSearchParams {
 		const hash = window.location.hash.startsWith('#')
@@ -28,6 +32,22 @@
 		}
 	}
 
+	function openIntro(e?: Event) {
+		e?.preventDefault();
+		showIntro = true;
+	}
+
+	function closeIntro() {
+		showIntro = false;
+		if (browser) {
+			try {
+				localStorage.setItem(INTRO_KEY, '1');
+			} catch {
+				// quota / private mode
+			}
+		}
+	}
+
 	onMount(() => {
 		loadPlaces();
 		const decoded = decodeView(paramsFromLocation());
@@ -40,6 +60,21 @@
 				? `${window.location.pathname}#${lastSerialized}`
 				: window.location.pathname;
 			history.replaceState(history.state, '', target);
+		}
+
+		// First-visit intro: only on the main app page, never on /help, never if there's
+		// a hash with state (likely a shared link).
+		const onMainPage = window.location.pathname === '/';
+		const hasHash = !!window.location.hash.replace(/^#/, '');
+		const alreadySeen = (() => {
+			try {
+				return localStorage.getItem(INTRO_KEY) === '1';
+			} catch {
+				return true;
+			}
+		})();
+		if (onMainPage && !hasHash && !alreadySeen) {
+			showIntro = true;
 		}
 
 		const onHash = () => {
@@ -59,6 +94,7 @@
 
 	$effect(() => {
 		if (!initialized || !browser) return;
+		if (window.location.pathname !== '/') return;
 		const serialized = encodeView(view);
 		if (serialized === lastSerialized) return;
 		lastSerialized = serialized;
@@ -79,10 +115,15 @@
 				title="Reset all selections and go home"
 			>🌦️ Weather Voodoo</a>
 		</h1>
+		<a class="help-link" href="/help" title="What this app does and how to use it">? Help</a>
 		<ShareBar onReset={resetAll} />
 	</header>
 	{@render children?.()}
 </div>
+
+{#if showIntro}
+	<IntroModal onClose={closeIntro} />
+{/if}
 
 <style>
 	header {
@@ -105,5 +146,17 @@
 	}
 	.home-link:hover {
 		opacity: 0.85;
+	}
+	.help-link {
+		color: var(--fg-dim);
+		font-size: 0.9em;
+		text-decoration: none;
+		padding: 0.35rem 0.6rem;
+		border: 1px solid var(--border);
+		border-radius: 6px;
+	}
+	.help-link:hover {
+		color: var(--fg);
+		background: var(--bg-elev, rgba(255, 255, 255, 0.05));
 	}
 </style>

--- a/weather-voodoo/src/routes/help/+page.svelte
+++ b/weather-voodoo/src/routes/help/+page.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+	import { defaultState } from '$lib/url-state';
+	import { setView } from '$lib/state.svelte';
+	import { browser } from '$app/environment';
+
+	function tryItOut() {
+		setView({
+			...defaultState(),
+			tab: 'route',
+			from: { lat: 7.7388, lon: 98.7784, label: 'Phi Phi Islands' },
+			to: { lat: 8.034, lon: 98.825, label: 'Ao Nang' }
+		});
+		if (browser) window.location.href = '/';
+	}
+</script>
+
+<svelte:head>
+	<title>Help · Weather Voodoo</title>
+</svelte:head>
+
+<article class="help">
+	<h1>How Weather Voodoo works</h1>
+	<p class="lede">
+		It picks the best hours of the next 3 days for a specific outdoor or marine trip — by
+		blending wind, gust, rain, wave height and visibility into a single 0–100 score, then
+		surfacing the best contiguous windows that fit your time and duration.
+	</p>
+
+	<h2>The two tabs</h2>
+	<ul>
+		<li>
+			<strong>Route</strong> — pick a <em>From</em> and <em>To</em>. The forecast is fused across 3 sample points along the line, taking the <em>worst-case</em> conditions hour-by-hour. Good for ferry/boat trips, drives, kayak crossings.
+		</li>
+		<li>
+			<strong>Fixed location</strong> — one place. Good for a beach day, hike, sunset session.
+		</li>
+	</ul>
+
+	<h2>The score</h2>
+	<p>
+		Each hour is scored 0–100 based on the activity type. The window score is the <em>worst hour</em> in the range (chain-as-strong-as-weakest-link); average score is the tiebreaker.
+	</p>
+	<ul>
+		<li><strong>Sea mode</strong> — ferry/boat + kayaking verdicts dominate (wave, gust, visibility).</li>
+		<li><strong>Land mode</strong> — sightseeing + hiking + photography verdicts (rain, wind, temp, visibility).</li>
+		<li><strong>Auto</strong> — detected from how much marine data exists at the place; you can override.</li>
+	</ul>
+
+	<h2>The big controls</h2>
+	<ul>
+		<li><strong>Earliest / Latest start</strong> — restrict candidate start times of day. Defaults to 00:00–23:00 in 30-min steps.</li>
+		<li><strong>Duration</strong> — how long you'll be out (1, 2, 3, 4, 6, 8, 12 h).</li>
+		<li><strong>Day tabs</strong> — Today / Tomorrow / Day after. Each tab can override the global earliest/latest/duration/mode just for that day.</li>
+	</ul>
+
+	<h2>Reading the table</h2>
+	<ul>
+		<li><strong>Time</strong> — 3-hour blocks (00–03, 03–06, …) with a small score chip. Click a block to expand into 1-hour rows.</li>
+		<li><strong>Temp</strong> — weather-condition icon + temperature in °C.</li>
+		<li><strong>Wind / gust</strong> — sustained / peak in knots, with cardinal direction the wind is coming from.</li>
+		<li><strong>Rain / Pₚ</strong> — mm/h + probability of precipitation.</li>
+		<li><strong>Cloud / Vis / Wave</strong> — cloud %, visibility km, significant wave height (Hₛ) m.</li>
+	</ul>
+
+	<h2>Sunrise &amp; sunset</h2>
+	<p>
+		The "☀️ Sunrise · 🌙 Sunset" line above each day's table shows the day's times. Night-time rows are tinted darker; hours that straddle a transition get a 🌅 / 🌇 marker in the time cell.
+	</p>
+
+	<h2>Recommendations</h2>
+	<p>
+		Above the score-coloured "Best across 3 days" card, the <strong>1st &amp; 2nd best windows</strong> are highlighted per day. Click one to jump-highlight it in the table below.
+	</p>
+
+	<h2>Saved places</h2>
+	<p>
+		Picking a place via search or "📍 Use my location" saves it in a chip row under the inputs. ★ pins so it never gets evicted; × removes a recent (pinned ones can't be removed by accident).
+	</p>
+
+	<h2>Sharing &amp; resetting</h2>
+	<ul>
+		<li>The whole state lives in the URL hash — <strong>📋 Copy link</strong> or <strong>🔗 Share</strong> copies the exact view you're on.</li>
+		<li><strong>↻ Reset</strong> (or clicking the 🌦️ logo) clears the current selection but <em>keeps</em> your saved places.</li>
+	</ul>
+
+	<h2>Tips</h2>
+	<ul>
+		<li>"Today" never proposes a window that already started — past hours still appear in the table with their scores, they're just not in the suggestions.</li>
+		<li>All times are in your local timezone.</li>
+		<li>The reference scale at the top of each day's table shows the good / caution / unsafe bands for each metric.</li>
+	</ul>
+
+	<div class="cta">
+		<button type="button" class="btn" onclick={tryItOut}>Try a sample route</button>
+		<a class="btn-ghost" href="/">Back to the app</a>
+	</div>
+</article>
+
+<style>
+	.help {
+		max-width: 760px;
+		margin: 0 auto;
+		line-height: 1.55;
+	}
+	.help h1 {
+		font-size: 1.6rem;
+		margin: 0 0 0.5rem;
+	}
+	.help h2 {
+		font-size: 1.05rem;
+		margin: 1.4rem 0 0.4rem;
+		color: var(--fg);
+	}
+	.lede {
+		color: var(--fg-dim);
+		font-size: 1.02rem;
+	}
+	.help ul {
+		padding-left: 1.2rem;
+		margin: 0.3rem 0 0.8rem;
+	}
+	.help li {
+		margin-bottom: 0.3rem;
+	}
+	.cta {
+		display: flex;
+		gap: 0.5rem;
+		flex-wrap: wrap;
+		margin-top: 1.6rem;
+	}
+</style>

--- a/weather-voodoo/src/routes/help/+page.svelte
+++ b/weather-voodoo/src/routes/help/+page.svelte
@@ -19,6 +19,9 @@
 </svelte:head>
 
 <article class="help">
+	<p class="back-top">
+		<a href="/">← Back to the app</a>
+	</p>
 	<h1>How Weather Voodoo works</h1>
 	<p class="lede">
 		It picks the best hours of the next 3 days for a specific outdoor or marine trip — by
@@ -127,5 +130,16 @@
 		gap: 0.5rem;
 		flex-wrap: wrap;
 		margin-top: 1.6rem;
+	}
+	.back-top {
+		margin: 0 0 0.6rem;
+		font-size: 0.9em;
+	}
+	.back-top a {
+		color: var(--fg-dim);
+		text-decoration: none;
+	}
+	.back-top a:hover {
+		color: var(--fg);
 	}
 </style>


### PR DESCRIPTION
## Summary
Two onboarding pieces:

1. **`/help` route** — a long-form, mobile-friendly explanation of what the app does, how scoring works, what each control means, how to read the table (incl. sunrise/sunset markers, 1st/2nd-best recommendations, saved places, reset behaviour, tips). Has a "Try a sample route" button that pre-fills Phi Phi → Ao Nang.
2. **First-visit `IntroModal`** — shown once per browser (gated by `localStorage["wv.introSeen.v1"]`) on the main page when there is no hash state (so shared links don't get interrupted). Two-paragraph summary + a link into `/help`.
3. **"? Help" link** in the page header so users can find the help any time.

## Other touches
- Layout's URL-hash sync now skips when on `/help` so navigating to the help page doesn't push the app state into its URL.

## Test plan
- [x] `pnpm test` / `pnpm check` clean.
- Manual on preview build:
  - Fresh browser → modal shows; "Got it" dismisses and isn't shown again.
  - Visiting a shared `/#…` URL doesn't trigger the modal.
  - "? Help" link goes to `/help`; "Back to the app" / "Try a sample route" return to `/`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9DMrLPT7hYfdCTsJgFF9q)_