### PR TITLE
[weather-voodoo] Mention PWA install in help page + intro modal

### DIFF
--- a/weather-voodoo/src/lib/components/IntroModal.svelte
+++ b/weather-voodoo/src/lib/components/IntroModal.svelte
@@ -37,6 +37,9 @@
 			<li><strong>Fixed location</strong>: one spot (beach, hike, sunset).</li>
 			<li>Pick a duration, a time window, and Sea / Land mode — the table colours each hour by score.</li>
 		</ul>
+		<p class="install-hint">
+			📲 Install to your home screen (iOS Share → <em>Add to Home Screen</em>; Android menu → <em>Install app</em>) — it works offline once the shell is cached.
+		</p>
 		<div class="intro-actions">
 			<a class="btn-ghost" href="/help" onclick={onClose}>Read the full help</a>
 			<button type="button" class="btn" onclick={onClose}>Got it</button>
@@ -80,6 +83,14 @@
 	}
 	.intro-card li {
 		margin-bottom: 0.25rem;
+	}
+	.install-hint {
+		font-size: 0.88em;
+		color: var(--fg-dim);
+		background: rgba(255, 255, 255, 0.05);
+		padding: 0.5rem 0.7rem;
+		border-radius: 8px;
+		margin: 0 0 1rem 0;
 	}
 	.intro-actions {
 		display: flex;

--- a/weather-voodoo/src/routes/help/+page.svelte
+++ b/weather-voodoo/src/routes/help/+page.svelte
@@ -86,6 +86,17 @@
 		<li><strong>↻ Reset</strong> (or clicking the 🌦️ logo) clears the current selection but <em>keeps</em> your saved places.</li>
 	</ul>
 
+	<h2>Install on your phone</h2>
+	<p>
+		Weather Voodoo is a PWA: you can install it to your home screen and launch it like a
+		native app. It also caches its shell so a flaky cell signal won't kill the page.
+	</p>
+	<ul>
+		<li><strong>iOS Safari</strong> — tap the Share button → <em>Add to Home Screen</em>.</li>
+		<li><strong>Android Chrome</strong> — three-dot menu → <em>Install app</em> (or wait for the install banner).</li>
+		<li><strong>Desktop Chrome / Edge</strong> — click the install icon in the address bar (or three-dot menu → <em>Install Weather Voodoo</em>).</li>
+	</ul>
+
 	<h2>Tips</h2>
 	<ul>
 		<li>"Today" never proposes a window that already started — past hours still appear in the table with their scores, they're just not in the suggestions.</li>


### PR DESCRIPTION
Follow-up to #23.

## Summary
PR #23 made the site installable as a PWA but the user-facing docs didn't mention it.

- **`/help`** — new "Install on your phone" section with the per-platform steps for iOS Safari, Android Chrome, and desktop Chrome/Edge, plus a note about offline shell caching.
- **`IntroModal`** — adds a single 📲 install hint so first-time users see it without needing to open the full help page.

## Test plan
- [x] Build clean.
- Manual on preview build:
  - Open the help page → "Install on your phone" section reads well on mobile.
  - Fresh browser (or wiped `localStorage`) → intro modal shows the install hint.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9DMrLPT7hYfdCTsJgFF9q)_