### PR TITLE
[weather-voodoo] Stick the day tabs to the top on scroll

### DIFF
--- a/weather-voodoo/src/app.css
+++ b/weather-voodoo/src/app.css
@@ -116,7 +116,13 @@ input[type='search'] {
 .day-tabs {
 	display: flex;
 	gap: 0.5rem;
-	margin: 1rem 0;
+	margin: 0 0 0.5rem;
+	padding: 0.6rem 0 0.5rem;
+	position: sticky;
+	top: 0;
+	z-index: 15;
+	background: var(--bg);
+	box-shadow: 0 4px 8px -4px rgba(0, 0, 0, 0.4);
 }
 
 .day-tab {
@@ -188,7 +194,7 @@ table.forecast thead.real-thead-hidden {
 
 .thead-mirror {
 	position: sticky;
-	top: 0;
+	top: var(--day-tabs-h, 0px);
 	z-index: 10;
 	overflow-x: scroll;
 	overflow-y: hidden;
@@ -382,7 +388,8 @@ tr.detail td {
 
 	.day-tabs {
 		gap: 0.35rem;
-		margin: 0.6rem 0;
+		margin: 0 0 0.4rem;
+		padding: 0.45rem 0 0.35rem;
 	}
 
 	.day-tab {

--- a/weather-voodoo/src/lib/components/DayTabs.svelte
+++ b/weather-voodoo/src/lib/components/DayTabs.svelte
@@ -3,6 +3,23 @@
 
 	let { day, onChange }: { day: DayKey; onChange: (d: DayKey) => void } = $props();
 
+	let bar: HTMLDivElement | undefined = $state.raw();
+
+	$effect(() => {
+		const el = bar;
+		if (!el || typeof document === 'undefined') return;
+		const sync = () => {
+			document.documentElement.style.setProperty('--day-tabs-h', `${el.offsetHeight}px`);
+		};
+		sync();
+		const ro = new ResizeObserver(sync);
+		ro.observe(el);
+		return () => {
+			ro.disconnect();
+			document.documentElement.style.removeProperty('--day-tabs-h');
+		};
+	});
+
 	function dayOfMonth(offset: number): number {
 		const d = new Date();
 		d.setDate(d.getDate() + offset);
@@ -16,7 +33,7 @@
 	]);
 </script>
 
-<div class="day-tabs" role="tablist">
+<div class="day-tabs" role="tablist" bind:this={bar}>
 	{#each items as item}
 		<button
 			class="day-tab"


### PR DESCRIPTION
## Summary
Day tabs (Today / Tomorrow / Day after) now stick to the top of the viewport while you scroll through the forecast — no need to scroll back up to switch days.

## Changes
- **`src/app.css`** — `.day-tabs` is `position: sticky; top: 0; z-index: 15` with `background: var(--bg)` and a soft drop-shadow so it reads as a floating bar. Mobile media query padding updated accordingly.
- **`src/lib/components/DayTabs.svelte`** — measures its rendered height via `ResizeObserver` and publishes it as the `--day-tabs-h` CSS custom property on the document root.
- **`src/app.css`** — `.thead-mirror`'s sticky offset becomes `top: var(--day-tabs-h, 0px)` so the forecast-table header pins directly beneath the day tabs (no overlap on any viewport).

## Test plan
- [x] `pnpm test` / `pnpm check` clean.
- Manual on preview build: scroll past the day tabs → tabs stay at the top, thead mirror sticks below them; switching day works without scrolling back; works on both mobile and desktop viewports.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9DMrLPT7hYfdCTsJgFF9q)_