### PR TITLE
[weather-voodoo] Sea routing via searoute-ts (Eurostat marnet)

### DIFF
--- a/weather-voodoo/package.json
+++ b/weather-voodoo/package.json
@@ -26,6 +26,7 @@
     "vitest": "^2.1.0"
   },
   "dependencies": {
-    "maplibre-gl": "^4.7.0"
+    "maplibre-gl": "^4.7.0",
+    "searoute-ts": "^2.0.0"
   }
 }

--- a/weather-voodoo/pnpm-lock.yaml
+++ b/weather-voodoo/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       maplibre-gl:
         specifier: ^4.7.0
         version: 4.7.1
+      searoute-ts:
+        specifier: ^2.0.0
+        version: 2.0.0
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
@@ -602,6 +605,45 @@ packages:
       svelte: ^5.0.0-next.96 || ^5.0.0
       vite: ^5.0.0
 
+  '@turf/bearing@7.3.5':
+    resolution: {integrity: sha512-/qabIt/IuPsGlE6RukJ0zOirc6afNxoK7fK1WBNVnHuJjeOpSkW+7q1QW5XQGXBMv3odcD0ZgRR+MBiAHduYSA==}
+
+  '@turf/clone@7.3.5':
+    resolution: {integrity: sha512-qfIaHj3410QEcTpiCRnTzhq8YrUp2gWrUIPLBAEFykopNxJkq1du1VrRzvuAo36ap2UV7KppkS6wGNypbcxswQ==}
+
+  '@turf/distance@7.3.5':
+    resolution: {integrity: sha512-uQAC63zg/l91KUxzfhqio7Ii3+UXTrPOVJScIdRj6EO6+9XHI4kC+AdyIS4cPAv14sZfJLIBxzMnzcGrss+kEA==}
+
+  '@turf/explode@7.3.5':
+    resolution: {integrity: sha512-Qdd7ehX5AF0DdpJl+JJyxws7jEmsZBRV35wTm+Lyhapuc3yLHU7tN5EqJ+2lVV7RkUgBXEFQV+34pmPLPGQn+w==}
+
+  '@turf/helpers@7.3.5':
+    resolution: {integrity: sha512-E/NMGV5MwbjjP7AJXBtsanC3yY8N2MQ87IGdIgkB2ji5AtBpwnH4L3gEqpYN4RlCJJWbLbzO91BbKv2waUd0eg==}
+
+  '@turf/invariant@7.3.5':
+    resolution: {integrity: sha512-ZVIvsBvjr8lO7WxC5zYNjRsjSDvyGvWkJMjuWaJjTU8x+1tmfNnw3gDX/TI2Sit83gcRYLYkNo23lB/udqx/Hg==}
+
+  '@turf/length@7.3.5':
+    resolution: {integrity: sha512-Bi+vEP54wt1ly3BRcCOP0nd2kGTYEhGk6haQxTpkrqr3XtmqDh8c3NowSgseN2cegIZRjwCOEC8eSsZ0JemJdA==}
+
+  '@turf/meta@7.3.5':
+    resolution: {integrity: sha512-r+ohqxoyqeigFB0oFrQx/YEHIkOKqcKpCjvZkvZs7Tkv+IFco5MezAd2zd4rzK+0DfFgDP3KpJc7HqrYjvEjhg==}
+
+  '@turf/nearest-point-on-line@7.3.5':
+    resolution: {integrity: sha512-MZn6OkEFZpjS6BNUANfqiHMIbQSivu7TNji3a+OAIrnPJ71vp8cbz0N2aVEa5M7I8ipvxoxAPIV3eqg3h280Vg==}
+
+  '@turf/point-to-line-distance@7.3.5':
+    resolution: {integrity: sha512-mR1NAIX+JfpYAJQ9u3gpIV37QzYvBOefDP+/16uBCAOM8Fp12goT8l7WdenT0dvB4wPibbqM2+2kyEl5u9XJog==}
+
+  '@turf/projection@7.3.5':
+    resolution: {integrity: sha512-G4bejYKT0vCQZryMhEoS9aLmP7ThDg6nb3zi3wPzELiTrGNOd2YgkWVheQDGCk4hcqEIWZc9fI2alaRSSkkLVw==}
+
+  '@turf/rhumb-bearing@7.3.5':
+    resolution: {integrity: sha512-pYjBAuQTND0+6Y+v+zlQ7Y68SGjP4iG8qJ5QKjFRbB/yeorTY3m9yiXIN4lSyno3TPzEgBeNULuo26H6ygDyng==}
+
+  '@turf/rhumb-distance@7.3.5':
+    resolution: {integrity: sha512-dBFxmKrjRaAdwc4SCmGyAS2BDPCH35IBNl++Ypd1RB8JR2D3khl3zrTvxrlJ5qoN1WDvyPbvDYCrt2UnTX+8Nw==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -869,6 +911,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  geojson-path-finder@2.1.0:
+    resolution: {integrity: sha512-ngg+rxoUSkhjOpKaQ2VpuvY6v2o/12JF1JF09AUzMg5iOVJ2dKLfT4vr8NleEk5pVwmx3nANyH8rK8mCn90LSA==}
+
   geojson-vt@4.0.3:
     resolution: {integrity: sha512-jR1MwkLaZGa8Zftct9ZFruyWFrdl9ZyD2OliXNy9Qq5bBPeg5wHVpBQF9p5GjnicSDQqvBVpysxTPKmWdsfWMA==}
 
@@ -1079,6 +1124,10 @@ packages:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
 
+  searoute-ts@2.0.0:
+    resolution: {integrity: sha512-xA4nzBKn8CMkoDZ3kd6Jv1vIpaL6gcrf9s/Gs487yybeQjYPKG1P4TKqxRwBpXd7xHZhgGtI1LLs3ASDmZ5pmQ==}
+    engines: {node: '>=18'}
+
   semver@7.8.0:
     resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
@@ -1161,6 +1210,9 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  tinyqueue@2.0.3:
+    resolution: {integrity: sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==}
+
   tinyqueue@3.0.0:
     resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
@@ -1178,6 +1230,9 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -1668,6 +1723,103 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@turf/bearing@7.3.5':
+    dependencies:
+      '@turf/helpers': 7.3.5
+      '@turf/invariant': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/clone@7.3.5':
+    dependencies:
+      '@turf/helpers': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/distance@7.3.5':
+    dependencies:
+      '@turf/helpers': 7.3.5
+      '@turf/invariant': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/explode@7.3.5':
+    dependencies:
+      '@turf/helpers': 7.3.5
+      '@turf/meta': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/helpers@7.3.5':
+    dependencies:
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/invariant@7.3.5':
+    dependencies:
+      '@turf/helpers': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/length@7.3.5':
+    dependencies:
+      '@turf/distance': 7.3.5
+      '@turf/helpers': 7.3.5
+      '@turf/meta': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/meta@7.3.5':
+    dependencies:
+      '@turf/helpers': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/nearest-point-on-line@7.3.5':
+    dependencies:
+      '@turf/distance': 7.3.5
+      '@turf/helpers': 7.3.5
+      '@turf/invariant': 7.3.5
+      '@turf/meta': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/point-to-line-distance@7.3.5':
+    dependencies:
+      '@turf/bearing': 7.3.5
+      '@turf/distance': 7.3.5
+      '@turf/helpers': 7.3.5
+      '@turf/invariant': 7.3.5
+      '@turf/meta': 7.3.5
+      '@turf/nearest-point-on-line': 7.3.5
+      '@turf/projection': 7.3.5
+      '@turf/rhumb-bearing': 7.3.5
+      '@turf/rhumb-distance': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/projection@7.3.5':
+    dependencies:
+      '@turf/clone': 7.3.5
+      '@turf/helpers': 7.3.5
+      '@turf/meta': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/rhumb-bearing@7.3.5':
+    dependencies:
+      '@turf/helpers': 7.3.5
+      '@turf/invariant': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
+  '@turf/rhumb-distance@7.3.5':
+    dependencies:
+      '@turf/helpers': 7.3.5
+      '@turf/invariant': 7.3.5
+      '@types/geojson': 7946.0.16
+      tslib: 2.8.1
+
   '@types/cookie@0.6.0': {}
 
   '@types/estree@1.0.8': {}
@@ -1943,6 +2095,13 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  geojson-path-finder@2.1.0:
+    dependencies:
+      '@turf/distance': 7.3.5
+      '@turf/explode': 7.3.5
+      '@turf/helpers': 7.3.5
+      tinyqueue: 2.0.3
+
   geojson-vt@4.0.3: {}
 
   get-stream@6.0.1: {}
@@ -2161,6 +2320,15 @@ snapshots:
     dependencies:
       mri: 1.2.0
 
+  searoute-ts@2.0.0:
+    dependencies:
+      '@turf/distance': 7.3.5
+      '@turf/helpers': 7.3.5
+      '@turf/length': 7.3.5
+      '@turf/meta': 7.3.5
+      '@turf/point-to-line-distance': 7.3.5
+      geojson-path-finder: 2.1.0
+
   semver@7.8.0: {}
 
   set-cookie-parser@3.1.0: {}
@@ -2258,6 +2426,8 @@ snapshots:
 
   tinypool@1.1.1: {}
 
+  tinyqueue@2.0.3: {}
+
   tinyqueue@3.0.0: {}
 
   tinyrainbow@1.2.0: {}
@@ -2267,6 +2437,8 @@ snapshots:
   totalist@3.0.1: {}
 
   tr46@0.0.3: {}
+
+  tslib@2.8.1: {}
 
   typescript@5.9.3: {}
 

--- a/weather-voodoo/src/lib/components/RouteView.svelte
+++ b/weather-voodoo/src/lib/components/RouteView.svelte
@@ -13,21 +13,27 @@
 
 	let loading = $state(false);
 	let error = $state<string | null>(null);
-	let result = $state<{ hours: FusedHour[]; timezone: string; daylight: DaylightDay[] } | null>(
-		null
-	);
+	type RouteMeta = { kind: 'sea'; lengthKm: number; greatCircleKm: number; detourRatio: number } | { kind: 'straight' };
+	let result = $state<{
+		hours: FusedHour[];
+		timezone: string;
+		daylight: DaylightDay[];
+		polyline: { lat: number; lon: number }[];
+		route: RouteMeta;
+	} | null>(null);
 
 	const markers = $derived(
 		[view.from, view.to].filter((m): m is LabeledPoint => m !== null)
 	);
 
 	const polyline = $derived(
-		view.from && view.to
-			? [
-					{ lat: view.from.lat, lon: view.from.lon },
-					{ lat: view.to.lat, lon: view.to.lon }
-				]
-			: undefined
+		result?.polyline ??
+			(view.from && view.to
+				? [
+						{ lat: view.from.lat, lon: view.from.lon },
+						{ lat: view.to.lat, lon: view.to.lon }
+					]
+				: undefined)
 	);
 
 	$effect(() => {
@@ -50,8 +56,19 @@
 					hours: FusedHour[];
 					timezone: string;
 					daylight?: DaylightDay[];
+					polyline?: { lat: number; lon: number }[];
+					route?: RouteMeta;
 				};
-				result = { hours: data.hours, timezone: data.timezone, daylight: data.daylight ?? [] };
+				result = {
+					hours: data.hours,
+					timezone: data.timezone,
+					daylight: data.daylight ?? [],
+					polyline: data.polyline ?? [
+						{ lat: from.lat, lon: from.lon },
+						{ lat: to.lat, lon: to.lon }
+					],
+					route: data.route ?? { kind: 'straight' }
+				};
 			})
 			.catch((e: unknown) => {
 				if (e instanceof DOMException && e.name === 'AbortError') return;
@@ -125,6 +142,16 @@
 		{#if view.to}<span>To: {view.to.label ?? `${view.to.lat.toFixed(3)}, ${view.to.lon.toFixed(3)}`}</span>{/if}
 		{#if !view.from && !view.to}<span>Tap the map to drop a pin — first tap is From, second is To.</span>{/if}
 	</div>
+	{#if result?.route.kind === 'sea'}
+		<div class="muted route-meta">
+			⚓ Sea route: <strong>{result.route.lengthKm.toFixed(0)} km</strong>
+			<span title="route length / great-circle length">(×{result.route.detourRatio.toFixed(2)} the great-circle line)</span>
+		</div>
+	{:else if view.from && view.to && result}
+		<div class="muted route-meta">
+			📐 Straight-line route — couldn't snap both endpoints to a marine network. Sample points may cross land.
+		</div>
+	{/if}
 </div>
 
 <div class="card" style="padding: 0;">
@@ -165,3 +192,14 @@
 		{/if}
 	</div>
 {/if}
+
+<style>
+	.route-meta {
+		margin-top: 0.4rem;
+		font-size: 0.85em;
+	}
+	.route-meta strong {
+		color: var(--fg);
+		font-variant-numeric: tabular-nums;
+	}
+</style>

--- a/weather-voodoo/src/lib/geo.ts
+++ b/weather-voodoo/src/lib/geo.ts
@@ -45,3 +45,37 @@ export function sampleAlongRoute(from: LatLng, to: LatLng, samples: number): Lat
 	}
 	return out;
 }
+
+function polylineKmLengths(line: LatLng[]): { cumulative: number[]; total: number } {
+	const cumulative: number[] = [0];
+	for (let i = 1; i < line.length; i++) {
+		cumulative.push(cumulative[i - 1] + haversineKm(line[i - 1], line[i]));
+	}
+	return { cumulative, total: cumulative[cumulative.length - 1] ?? 0 };
+}
+
+function interpolate(a: LatLng, b: LatLng, t: number): LatLng {
+	return { lat: a.lat + (b.lat - a.lat) * t, lon: a.lon + (b.lon - a.lon) * t };
+}
+
+export function sampleAlongPolyline(line: LatLng[], samples: number): LatLng[] {
+	if (line.length === 0) return [];
+	if (line.length === 1) return Array(samples).fill(line[0]);
+	if (samples < 2) return [line[0], line[line.length - 1]];
+
+	const { cumulative, total } = polylineKmLengths(line);
+	if (total === 0) return Array(samples).fill(line[0]);
+
+	const out: LatLng[] = [];
+	for (let s = 0; s < samples; s++) {
+		const target = (s / (samples - 1)) * total;
+		// Find the segment containing the target distance
+		let i = 1;
+		while (i < cumulative.length - 1 && cumulative[i] < target) i++;
+		const segStart = cumulative[i - 1];
+		const segLen = cumulative[i] - segStart;
+		const t = segLen === 0 ? 0 : (target - segStart) / segLen;
+		out.push(interpolate(line[i - 1], line[i], t));
+	}
+	return out;
+}

--- a/weather-voodoo/src/lib/server/sea-routing.ts
+++ b/weather-voodoo/src/lib/server/sea-routing.ts
@@ -1,0 +1,46 @@
+import { seaRoute, SnapFailedError, NoRouteError } from 'searoute-ts';
+import type { LatLng } from '$lib/types';
+
+export type SeaRouteResult = {
+	polyline: LatLng[];
+	lengthKm: number;
+	greatCircleKm: number;
+	detourRatio: number;
+};
+
+/**
+ * Compute the shortest maritime route between two points using Eurostat's
+ * marnet (via searoute-ts). Returns null when either endpoint can't be
+ * snapped to the network (e.g. inland), no path exists, or the snap distance
+ * is far enough that the result wouldn't be a meaningful sea route — caller
+ * should fall back to a straight line in that case.
+ *
+ * `maxSnapKm` guards against snapping a deeply inland location to a faraway
+ * coast (which would look correct but be nonsense). 50 km covers harbours
+ * and near-coast pickups.
+ */
+export function computeSeaRoute(
+	from: LatLng,
+	to: LatLng,
+	maxSnapKm = 50
+): SeaRouteResult | null {
+	try {
+		const route = seaRoute([from.lon, from.lat], [to.lon, to.lat], { units: 'kilometers' });
+		const { length, greatCircleLength, detourRatio, originSnapKm, destinationSnapKm } =
+			route.properties;
+		if (originSnapKm > maxSnapKm || destinationSnapKm > maxSnapKm) return null;
+		const coords = route.geometry.coordinates;
+		if (!coords || coords.length < 2) return null;
+		const polyline: LatLng[] = coords.map(([lon, lat]) => ({ lat, lon }));
+		return {
+			polyline,
+			lengthKm: length,
+			greatCircleKm: greatCircleLength,
+			detourRatio
+		};
+	} catch (e) {
+		if (e instanceof SnapFailedError) return null;
+		if (e instanceof NoRouteError) return null;
+		throw e;
+	}
+}

--- a/weather-voodoo/src/routes/api/route/+server.ts
+++ b/weather-voodoo/src/routes/api/route/+server.ts
@@ -1,7 +1,8 @@
 import { error, json } from '@sveltejs/kit';
 import { fetchForecast, fetchMarine } from '$lib/server/openmeteo';
+import { computeSeaRoute } from '$lib/server/sea-routing';
 import { fuseRoute } from '$lib/fusion';
-import { sampleAlongRoute } from '$lib/geo';
+import { sampleAlongPolyline, sampleAlongRoute } from '$lib/geo';
 import type { RequestHandler } from './$types';
 
 function parsePoint(raw: string | null): { lat: number; lon: number } | null {
@@ -20,8 +21,13 @@ export const GET: RequestHandler = async ({ url }) => {
 	if (!from || !to) throw error(400, 'from and to required as lat,lon');
 	const samples = Math.min(Math.max(Number(url.searchParams.get('samples') ?? '3'), 2), 7);
 	const days = Math.min(Math.max(Number(url.searchParams.get('days') ?? '3'), 1), 5);
+	const land = url.searchParams.get('land') === '1';
 
-	const points = sampleAlongRoute(from, to, samples);
+	const sea = land ? null : computeSeaRoute(from, to);
+	const routePolyline = sea ? sea.polyline : [from, to];
+	const points = sea
+		? sampleAlongPolyline(sea.polyline, samples)
+		: sampleAlongRoute(from, to, samples);
 
 	try {
 		const results = await Promise.all(
@@ -36,7 +42,16 @@ export const GET: RequestHandler = async ({ url }) => {
 				timezone: results[0]?.timezone ?? 'UTC',
 				samplePoints: points,
 				hours,
-				daylight: results[0]?.daylight ?? []
+				daylight: results[0]?.daylight ?? [],
+				polyline: routePolyline,
+				route: sea
+					? {
+							kind: 'sea',
+							lengthKm: sea.lengthKm,
+							greatCircleKm: sea.greatCircleKm,
+							detourRatio: sea.detourRatio
+						}
+					: { kind: 'straight' }
 			},
 			{ headers: { 'cache-control': 'public, s-maxage=600, stale-while-revalidate=3600' } }
 		);

--- a/weather-voodoo/tests/geo.test.ts
+++ b/weather-voodoo/tests/geo.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { haversineKm, midpoint, sampleAlongRoute } from '../src/lib/geo';
+import { haversineKm, midpoint, sampleAlongPolyline, sampleAlongRoute } from '../src/lib/geo';
 
 describe('geo', () => {
 	it('haversine returns ~33 km Phi Phi to Ao Nang', () => {
@@ -24,5 +24,32 @@ describe('geo', () => {
 		expect(pts[0]).toEqual(a);
 		expect(pts[4]).toEqual(b);
 		expect(pts[2].lat).toBeCloseTo(5, 5);
+	});
+
+	it('sampleAlongPolyline returns endpoints + by-distance interior samples', () => {
+		// L-shape: 0,0 → 10,0 (≈1112 km) → 10,10 (≈1110 km)
+		const line = [
+			{ lat: 0, lon: 0 },
+			{ lat: 10, lon: 0 },
+			{ lat: 10, lon: 10 }
+		];
+		const pts = sampleAlongPolyline(line, 3);
+		expect(pts.length).toBe(3);
+		expect(pts[0]).toEqual(line[0]);
+		expect(pts[2]).toEqual(line[2]);
+		// Mid-distance sample should be near the corner since the two legs are
+		// nearly equal-length — within a few hundred km of (10, 0).
+		expect(pts[1].lat).toBeGreaterThan(8);
+		expect(pts[1].lon).toBeLessThan(2);
+	});
+
+	it('sampleAlongPolyline degrades gracefully for tiny inputs', () => {
+		expect(sampleAlongPolyline([], 3)).toEqual([]);
+		const one = sampleAlongPolyline([{ lat: 1, lon: 2 }], 3);
+		expect(one).toEqual([
+			{ lat: 1, lon: 2 },
+			{ lat: 1, lon: 2 },
+			{ lat: 1, lon: 2 }
+		]);
 	});
 });


### PR DESCRIPTION
Closes #30 (with an honest caveat — see below).

## Summary
Replaces the straight diagonal between two ports with the **shortest maritime path** from the Eurostat marnet network (via `searoute-ts`, MIT-licensed, offline). The map polyline + the 3 forecast sample points now follow that path when both endpoints can be snapped to the network.

## Changes
- **`pnpm add searoute-ts`** — Eurostat 2025 marnet, bundled, no API key.
- **`src/lib/server/sea-routing.ts`** — wraps the library with a `maxSnapKm = 50` guard so far-from-network endpoints fall back gracefully.
- **`src/lib/geo.ts`** — new `sampleAlongPolyline(line, n)` that distributes N samples by cumulative haversine distance along a multi-segment path.
- **`/api/route/+server.ts`** — tries `computeSeaRoute` first; samples along the real sea path when available; returns `polyline` + `route` meta (kind / lengthKm / greatCircleKm / detourRatio).
- **`RouteView.svelte`** — consumes the polyline so the map draws the actual path; shows a small `⚓ Sea route: X km (×N the great-circle line)` note. When the bundled marnet doesn't cover the region, falls back to the previous diagonal + a `📐 couldn't snap` note.

## Caveat — bundled Eurostat marnet coverage
The bundled network is built for **ocean shipping lanes**. Smoke-tested in the Andaman Sea:

```
Phi Phi → Ao Nang (great-circle 33 km): snap distance 213 km → falls back to straight line
Krabi → Phuket   (great-circle 70 km): snap distance 175 km → falls back to straight line
Bangkok → Phuket (great-circle 696 km): snap distance OK, route 2534 km, ×3.6 detour ✓
```

So for short coastal hops in SE Asia this PR silently leaves the diagonal in place. For longer cross-ocean routes it works. Two follow-ups make sense:

1. A **land-crossing warning** even when sea-routing fails (use a coastline polygon to flag when the diagonal crosses land).
2. A **denser local marine graph** (custom GeoJSON) for the regions we care about.

I'd treat this PR as "ships the right plumbing, plus a fallback that's no worse than the previous behaviour" — and open a follow-up issue for the local-coverage problem.

## Test plan
- [x] `pnpm test` — 75 passing (+2 new geo tests).
- [x] Smoke test of the library (`/tmp/pw-debug/searoute-smoke.mjs`).
- [ ] Manual on preview: pick two oceanic ports (e.g. Singapore → Mumbai) — should draw the actual route. Pick two nearby Andaman ports — should fall back with the "couldn't snap" note.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9DMrLPT7hYfdCTsJgFF9q)_