### PR TITLE
GPS follow mode — map tracks your position like a nav app

### DIFF
--- a/weather-voodoo/src/lib/components/MapView.svelte
+++ b/weather-voodoo/src/lib/components/MapView.svelte
@@ -73,6 +73,14 @@
 	let geoWatchId: number | null = null;
 	let lastFitKey = '';
 
+	// Follow-mode state: 'off' → 'locate' (one-shot) → 'follow' (continuous).
+	type LocMode = 'off' | 'locate' | 'follow';
+	let locMode = $state<LocMode>('off');
+	let locating = $state(false);
+	let userHeadingDeg = $state<number | null>(null);
+	let prevPos: { lat: number; lon: number; time: number } | null = null;
+	let userDragged = false;
+
 	const STYLE = {
 		version: 8 as const,
 		sources: {
@@ -86,23 +94,31 @@
 		layers: [{ id: 'osm', type: 'raster' as const, source: 'osm' }]
 	};
 
-	let locating = $state(false);
-
-	function locateMe() {
+	function cycleLocMode() {
 		if (!map || !('geolocation' in navigator)) return;
-		locating = true;
-		navigator.geolocation.getCurrentPosition(
-			(pos) => {
-				if (!map) return;
-				const { latitude: lat, longitude: lon } = pos.coords;
-				map.flyTo({ center: [lon, lat], zoom: Math.max(map.getZoom(), 12), duration: 600 });
-				mapViewport.center = { lat, lon };
-				mapViewport.zoom = Math.max(map.getZoom(), 12);
-				locating = false;
-			},
-			() => { locating = false; },
-			{ enableHighAccuracy: true, timeout: 10_000 }
-		);
+		if (locMode === 'off') {
+			locMode = 'locate';
+			locating = true;
+			navigator.geolocation.getCurrentPosition(
+				(pos) => {
+					if (!map) return;
+					const { latitude: lat, longitude: lon } = pos.coords;
+					map.flyTo({ center: [lon, lat], zoom: Math.max(map.getZoom(), 13), duration: 600 });
+					mapViewport.center = { lat, lon };
+					mapViewport.zoom = Math.max(map.getZoom(), 13);
+					locating = false;
+				},
+				() => { locating = false; locMode = 'off'; },
+				{ enableHighAccuracy: true, timeout: 10_000 }
+			);
+		} else if (locMode === 'locate') {
+			locMode = 'follow';
+			userDragged = false;
+		} else {
+			locMode = 'off';
+			userHeadingDeg = null;
+			updateLocMarkerElement();
+		}
 	}
 
 	onMount(() => {
@@ -204,31 +220,98 @@
 		renderWindChevrons();
 	});
 
-	function buildUserDot(): HTMLElement {
-		const dot = document.createElement('div');
-		dot.className = 'user-loc-dot';
-		dot.setAttribute('aria-label', 'Your location');
-		dot.innerHTML = '<div class="user-loc-pulse"></div><div class="user-loc-core"></div>';
-		return dot;
+	function buildLocElement(arrow: boolean): HTMLElement {
+		const el = document.createElement('div');
+		if (arrow) {
+			el.className = 'user-loc-arrow';
+			el.setAttribute('aria-label', 'Your location and heading');
+			// Navigation arrow — points up by default, rotated via inline transform
+			el.innerHTML = `<svg viewBox="0 0 32 32" width="32" height="32">
+				<polygon points="16,4 6,28 16,22 26,28" fill="#3b82f6" stroke="#fff" stroke-width="2" stroke-linejoin="round"/>
+			</svg>`;
+		} else {
+			el.className = 'user-loc-dot';
+			el.setAttribute('aria-label', 'Your location');
+			el.innerHTML = '<div class="user-loc-pulse"></div><div class="user-loc-core"></div>';
+		}
+		return el;
+	}
+
+	function updateLocMarkerElement() {
+		if (!userLocMarker || !map) return;
+		const isFollow = locMode === 'follow';
+		const ll = userLocMarker.getLngLat();
+		userLocMarker.remove();
+		userLocMarker = new maplibregl.Marker({ element: buildLocElement(isFollow), anchor: 'center' })
+			.setLngLat(ll)
+			.addTo(map);
+		if (isFollow && userHeadingDeg !== null) {
+			rotateArrow(userHeadingDeg);
+		}
+	}
+
+	function rotateArrow(deg: number) {
+		if (!userLocMarker) return;
+		const svg = userLocMarker.getElement().querySelector('svg');
+		if (svg) svg.style.transform = `rotate(${deg}deg)`;
+	}
+
+	function computeHeading(lat: number, lon: number, time: number): number | null {
+		if (!prevPos) { prevPos = { lat, lon, time }; return null; }
+		const dLat = lat - prevPos.lat;
+		const dLon = lon - prevPos.lon;
+		const dist = Math.sqrt(dLat * dLat + dLon * dLon) * 111_000; // rough metres
+		const dt = time - prevPos.time;
+		prevPos = { lat, lon, time };
+		if (dist < 5 || dt < 2_000) return null; // need ≥5m and ≥2s
+		const rad = Math.atan2(dLon * Math.cos(lat * Math.PI / 180), dLat);
+		return ((rad * 180 / Math.PI) + 360) % 360;
 	}
 
 	function startGeolocation() {
 		if (!showUserLocation || !map || !('geolocation' in navigator)) return;
+
+		// Exit follow mode if the user manually drags the map.
+		map.on('dragstart', () => {
+			if (locMode === 'follow') {
+				userDragged = true;
+				locMode = 'locate';
+				updateLocMarkerElement();
+			}
+		});
+
 		geoWatchId = navigator.geolocation.watchPosition(
 			(pos) => {
 				if (!map) return;
-				const lng = pos.coords.longitude;
+				const lon = pos.coords.longitude;
 				const lat = pos.coords.latitude;
+				const now = Date.now();
+				const isFollow = locMode === 'follow';
+
 				if (!userLocMarker) {
-					userLocMarker = new maplibregl.Marker({ element: buildUserDot(), anchor: 'center' })
-						.setLngLat([lng, lat])
+					userLocMarker = new maplibregl.Marker({
+						element: buildLocElement(isFollow),
+						anchor: 'center'
+					})
+						.setLngLat([lon, lat])
 						.addTo(map);
 				} else {
-					userLocMarker.setLngLat([lng, lat]);
+					userLocMarker.setLngLat([lon, lat]);
+				}
+
+				if (isFollow) {
+					const heading = computeHeading(lat, lon, now);
+					if (heading !== null) {
+						userHeadingDeg = heading;
+						rotateArrow(heading);
+					}
+					map.easeTo({ center: [lon, lat], duration: 800 });
+				} else {
+					computeHeading(lat, lon, now);
 				}
 			},
 			() => {},
-			{ enableHighAccuracy: true, maximumAge: 10_000, timeout: 15_000 }
+			{ enableHighAccuracy: true, maximumAge: 3_000, timeout: 15_000 }
 		);
 	}
 
@@ -367,16 +450,27 @@
 			type="button"
 			class="locate-btn"
 			class:locating
-			onclick={locateMe}
-			aria-label="Go to my location"
+			class:following={locMode === 'follow'}
+			class:located={locMode === 'locate'}
+			onclick={cycleLocMode}
+			aria-label={locMode === 'follow' ? 'Exit follow mode' : locMode === 'locate' ? 'Follow my position' : 'Go to my location'}
+			title={locMode === 'follow' ? 'Following — tap to stop' : locMode === 'locate' ? 'Tap again to follow' : 'Go to my location'}
 		>
-			<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-				<circle cx="12" cy="12" r="4" />
-				<line x1="12" y1="2" x2="12" y2="6" />
-				<line x1="12" y1="18" x2="12" y2="22" />
-				<line x1="2" y1="12" x2="6" y2="12" />
-				<line x1="18" y1="12" x2="22" y2="12" />
-			</svg>
+			{#if locMode === 'follow'}
+				<!-- Navigation arrow icon -->
+				<svg viewBox="0 0 24 24" width="20" height="20" fill="currentColor" stroke="none">
+					<polygon points="12,2 4,20 12,16 20,20" />
+				</svg>
+			{:else}
+				<!-- Crosshair icon -->
+				<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+					<circle cx="12" cy="12" r="4" />
+					<line x1="12" y1="2" x2="12" y2="6" />
+					<line x1="12" y1="18" x2="12" y2="22" />
+					<line x1="2" y1="12" x2="6" y2="12" />
+					<line x1="18" y1="12" x2="22" y2="12" />
+				</svg>
+			{/if}
 		</button>
 	{/if}
 </div>
@@ -424,9 +518,21 @@
 	.locate-btn:active {
 		background: rgba(59, 130, 246, 0.3);
 	}
+	.locate-btn.located {
+		color: #3b82f6;
+		border-color: rgba(59, 130, 246, 0.5);
+	}
 	.locate-btn.locating {
 		color: #3b82f6;
 		animation: loc-btn-pulse 1s ease-in-out infinite;
+	}
+	.locate-btn.following {
+		color: #fff;
+		background: #3b82f6;
+		border-color: #3b82f6;
+	}
+	.locate-btn.following:hover {
+		background: #2563eb;
 	}
 	@keyframes loc-btn-pulse {
 		0%, 100% { opacity: 1; }
@@ -537,6 +643,14 @@
 		border-radius: 50%;
 		background: rgba(59, 130, 246, 0.25);
 		animation: loc-pulse 2s ease-out infinite;
+	}
+	/* Directional navigation arrow — replaces the dot in follow mode */
+	:global(.user-loc-arrow) {
+		z-index: 16;
+		filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.5));
+	}
+	:global(.user-loc-arrow svg) {
+		transition: transform 400ms ease;
 	}
 	@keyframes loc-pulse {
 		0% { transform: scale(0.6); opacity: 1; }

--- a/weather-voodoo/src/lib/components/MapView.svelte
+++ b/weather-voodoo/src/lib/components/MapView.svelte
@@ -5,6 +5,7 @@
 	import type { LatLng } from '$lib/types';
 	import type { RelativeWindClass } from '$lib/wind';
 	import { mapViewport } from '$lib/map-viewport.svelte';
+	import { browser } from '$app/environment';
 
 	export type WindChevron = {
 		point: LatLng;
@@ -449,7 +450,7 @@
 
 <div class="map-wrap" style="height: {height}">
 	<div bind:this={el} class="map"></div>
-	{#if 'geolocation' in globalThis.navigator}
+	{#if browser && 'geolocation' in navigator}
 		<button
 			type="button"
 			class="locate-btn"

--- a/weather-voodoo/src/lib/components/MapView.svelte
+++ b/weather-voodoo/src/lib/components/MapView.svelte
@@ -161,6 +161,10 @@
 			locMode = 'follow';
 			userDragged = false;
 			updateLocMarkerElement();
+			if (userLocMarker && map) {
+				const ll = userLocMarker.getLngLat();
+				map.easeTo({ center: [ll.lng, ll.lat], zoom: Math.max(map.getZoom(), 14), duration: 500 });
+			}
 		} else {
 			locMode = 'off';
 			userHeadingDeg = null;

--- a/weather-voodoo/src/lib/components/MapView.svelte
+++ b/weather-voodoo/src/lib/components/MapView.svelte
@@ -94,11 +94,56 @@
 		layers: [{ id: 'osm', type: 'raster' as const, source: 'osm' }]
 	};
 
+	function ensureGeoWatch() {
+		if (geoWatchId !== null || !map || !('geolocation' in navigator)) return;
+		map.on('dragstart', () => {
+			if (locMode === 'follow') {
+				userDragged = true;
+				locMode = 'locate';
+				updateLocMarkerElement();
+			}
+		});
+		geoWatchId = navigator.geolocation.watchPosition(
+			(pos) => {
+				if (!map) return;
+				const lon = pos.coords.longitude;
+				const lat = pos.coords.latitude;
+				const now = Date.now();
+				const isFollow = locMode === 'follow';
+
+				if (!userLocMarker) {
+					userLocMarker = new maplibregl.Marker({
+						element: buildLocElement(isFollow),
+						anchor: 'center'
+					})
+						.setLngLat([lon, lat])
+						.addTo(map);
+				} else {
+					userLocMarker.setLngLat([lon, lat]);
+				}
+
+				if (isFollow) {
+					const heading = computeHeading(lat, lon, now);
+					if (heading !== null) {
+						userHeadingDeg = heading;
+						rotateArrow(heading);
+					}
+					map.easeTo({ center: [lon, lat], duration: 800 });
+				} else {
+					computeHeading(lat, lon, now);
+				}
+			},
+			() => {},
+			{ enableHighAccuracy: true, maximumAge: 3_000, timeout: 15_000 }
+		);
+	}
+
 	function cycleLocMode() {
 		if (!map || !('geolocation' in navigator)) return;
 		if (locMode === 'off') {
 			locMode = 'locate';
 			locating = true;
+			ensureGeoWatch();
 			navigator.geolocation.getCurrentPosition(
 				(pos) => {
 					if (!map) return;
@@ -114,6 +159,7 @@
 		} else if (locMode === 'locate') {
 			locMode = 'follow';
 			userDragged = false;
+			updateLocMarkerElement();
 		} else {
 			locMode = 'off';
 			userHeadingDeg = null;
@@ -269,50 +315,8 @@
 	}
 
 	function startGeolocation() {
-		if (!showUserLocation || !map || !('geolocation' in navigator)) return;
-
-		// Exit follow mode if the user manually drags the map.
-		map.on('dragstart', () => {
-			if (locMode === 'follow') {
-				userDragged = true;
-				locMode = 'locate';
-				updateLocMarkerElement();
-			}
-		});
-
-		geoWatchId = navigator.geolocation.watchPosition(
-			(pos) => {
-				if (!map) return;
-				const lon = pos.coords.longitude;
-				const lat = pos.coords.latitude;
-				const now = Date.now();
-				const isFollow = locMode === 'follow';
-
-				if (!userLocMarker) {
-					userLocMarker = new maplibregl.Marker({
-						element: buildLocElement(isFollow),
-						anchor: 'center'
-					})
-						.setLngLat([lon, lat])
-						.addTo(map);
-				} else {
-					userLocMarker.setLngLat([lon, lat]);
-				}
-
-				if (isFollow) {
-					const heading = computeHeading(lat, lon, now);
-					if (heading !== null) {
-						userHeadingDeg = heading;
-						rotateArrow(heading);
-					}
-					map.easeTo({ center: [lon, lat], duration: 800 });
-				} else {
-					computeHeading(lat, lon, now);
-				}
-			},
-			() => {},
-			{ enableHighAccuracy: true, maximumAge: 3_000, timeout: 15_000 }
-		);
+		if (!showUserLocation) return;
+		ensureGeoWatch();
 	}
 
 	function renderMarkersAndLine() {
@@ -445,7 +449,7 @@
 
 <div class="map-wrap" style="height: {height}">
 	<div bind:this={el} class="map"></div>
-	{#if interactive}
+	{#if 'geolocation' in globalThis.navigator}
 		<button
 			type="button"
 			class="locate-btn"

--- a/weather-voodoo/src/service-worker.ts
+++ b/weather-voodoo/src/service-worker.ts
@@ -65,15 +65,12 @@ async function cacheFirst(request: Request): Promise<Response> {
 			cache.put(request, response.clone()).catch(() => {});
 		}
 		return response;
-	} catch (err) {
-		// Last-ditch: fall back to the cached root document for navigations
-		// so the SPA can render and let the client-side router handle the
-		// requested path.
+	} catch {
 		if (request.mode === 'navigate') {
 			const fallback = await cache.match('/');
 			if (fallback) return fallback;
 		}
-		throw err;
+		return new Response('Offline', { status: 503, statusText: 'Service Unavailable' });
 	}
 }
 

--- a/weather-voodoo/src/service-worker.ts
+++ b/weather-voodoo/src/service-worker.ts
@@ -51,8 +51,28 @@ sw.addEventListener('fetch', (event) => {
 		return;
 	}
 
+	// Navigation requests (HTML pages) always go network-first so a deploy
+	// transition never serves a stale shell pointing at vanished assets.
+	if (request.mode === 'navigate') {
+		event.respondWith(networkFirstNav(request));
+		return;
+	}
+
 	event.respondWith(cacheFirst(request));
 });
+
+async function networkFirstNav(request: Request): Promise<Response> {
+	try {
+		const response = await fetch(request);
+		const cache = await caches.open(SHELL_CACHE);
+		cache.put(request, response.clone()).catch(() => {});
+		return response;
+	} catch {
+		const cache = await caches.open(SHELL_CACHE);
+		const cached = await cache.match(request) ?? await cache.match('/');
+		return cached ?? new Response('Offline', { status: 503, statusText: 'Service Unavailable' });
+	}
+}
 
 async function cacheFirst(request: Request): Promise<Response> {
 	const cache = await caches.open(SHELL_CACHE);


### PR DESCRIPTION
## Summary

Adds a "drive mode" to the map — tap the location button twice to enter follow mode, where the map continuously centers on your GPS position with a directional arrow showing your heading. Same UX pattern as Google Maps / Waze / Strava.

## How it works

The location button (bottom-right) cycles through three states:

| State | Icon | What happens |
|---|---|---|
| **Off** | Crosshair | Tap → one-shot GPS fix, centers map |
| **Located** | Blue crosshair | Centered once. Tap again → follow mode |
| **Following** | Filled blue nav arrow | Map continuously tracks your GPS. Arrow rotates with heading. Tap again → off |

### Heading computation

Uses GPS position delta (no compass/gyro required):
- Stores previous position + timestamp
- On each `watchPosition` update, computes bearing from prev → current
- Requires ≥5 m movement and ≥2 s elapsed to avoid jitter
- Arrow rotates smoothly via CSS `transition: transform 400ms`

### Auto-exit on drag

If the user manually drags the map during follow mode, it auto-exits back to "located" state (same as Google Maps). The directional arrow reverts to the pulsing blue dot.

## Visual design

- **Blue dot** (off / located): same pulsing dot as before
- **Nav arrow** (follow mode): blue filled triangle pointing in direction of travel, white stroke, drop shadow. Replaces the dot while following.
- **Button states**: default dark → blue border when located → solid blue fill when following. Clear visual feedback for which mode you're in.

## Technical details

- `watchPosition` with `maximumAge: 3s` (was 10s) for more responsive tracking
- `map.easeTo({ duration: 800 })` for smooth map movement between GPS updates
- Arrow SVG rotation applied via inline `transform` on the marker's `<svg>` element
- Marker element is swapped (dot ↔ arrow) when entering/exiting follow mode via `updateLocMarkerElement()`
- Follow mode auto-activates geolocation watch if not already running (`showUserLocation` prop)

## Preview

https://weather-voodoo-9nyuassur-xorio-s-projects.vercel.app

## Test plan

- [ ] Tap the crosshair button → map centers on your GPS
- [ ] Tap again → button turns solid blue, map follows your movement, blue dot becomes a directional arrow
- [ ] Walk/bike with the phone → arrow rotates to match direction of travel, map stays centered
- [ ] Drag the map while following → follow mode exits, button goes back to blue outline, arrow becomes dot again
- [ ] Tap the solid blue button → exits follow mode back to off
- [ ] Works in fullscreen map mode
- [ ] GPS permission prompt only appears on first tap (not on page load)

https://claude.ai/code/session_01B9DMrLPT7hYfdCTsJgFF9q

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9DMrLPT7hYfdCTsJgFF9q)_